### PR TITLE
Implement and document wildcard search for search_types tool

### DIFF
--- a/McpTools.cs
+++ b/McpTools.cs
@@ -139,7 +139,7 @@ namespace dnSpy.Extension.MCP
                         ["properties"] = new Dictionary<string, object> {
                             ["query"] = new Dictionary<string, object> {
                                 ["type"] = "string",
-                                ["description"] = "Search query. Use * for wildcards (e.g., 'Player*' for types starting with Player, '*Controller' for types ending with Controller, '*Player*' for types containing Player). Without wildcards, performs case-insensitive substring matching."
+                                ["description"] = "Search query. Wildcards (*) match against FullName (namespace + type name). Recommended patterns: '*TypeName' for suffix (e.g., '*Controller' finds MyNamespace.PlayerController), '*.Keyword*' for types containing keyword, 'Full.Namespace.Path.*' for specific namespace. Without wildcards, performs case-insensitive substring matching (e.g., 'Controller' finds all types with 'Controller' in name)."
                             },
                             ["cursor"] = new Dictionary<string, object> {
                                 ["type"] = "string",

--- a/McpTools.cs
+++ b/McpTools.cs
@@ -139,7 +139,7 @@ namespace dnSpy.Extension.MCP
                         ["properties"] = new Dictionary<string, object> {
                             ["query"] = new Dictionary<string, object> {
                                 ["type"] = "string",
-                                ["description"] = "Search query (supports wildcards)"
+                                ["description"] = "Search query. Use * for wildcards (e.g., 'Player*' for types starting with Player, '*Controller' for types ending with Controller, '*Player*' for types containing Player). Without wildcards, performs case-insensitive substring matching."
                             },
                             ["cursor"] = new Dictionary<string, object> {
                                 ["type"] = "string",
@@ -602,9 +602,20 @@ namespace dnSpy.Extension.MCP
 
             var (offset, pageSize) = DecodeCursor(cursor);
 
+            // Check if query contains wildcards
+            bool hasWildcard = query.Contains("*");
+            System.Text.RegularExpressions.Regex? regex = null;
+
+            if (hasWildcard)
+            {
+                // Convert wildcard pattern to regex
+                var regexPattern = "^" + System.Text.RegularExpressions.Regex.Escape(queryLower).Replace("\\*", ".*") + "$";
+                regex = new System.Text.RegularExpressions.Regex(regexPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            }
+
             var results = documentTreeView.GetAllModuleNodes()
                 .SelectMany(m => m.Document?.ModuleDef?.Types ?? Enumerable.Empty<TypeDef>())
-                .Where(t => t.FullName.ToLowerInvariant().Contains(queryLower))
+                .Where(t => hasWildcard ? regex!.IsMatch(t.FullName) : t.FullName.ToLowerInvariant().Contains(queryLower))
                 .Select(t => new
                 {
                     AssemblyName = t.Module?.Assembly?.Name.String ?? "Unknown",


### PR DESCRIPTION
## Summary

Adds regex-based wildcard pattern matching to the `search_types` MCP tool, enabling more precise type searches across loaded assemblies. The implementation works with the existing pagination system.

## Changes

- ✅ Implemented wildcard pattern matching using regex
- ✅ Wildcards match against `FullName` (namespace + type name)
- ✅ Backward compatible: plain text queries still use substring matching
- ✅ Works seamlessly with cursor-based pagination
- ✅ Clear documentation with recommended usage patterns

## How It Works

**Wildcard Patterns** (when query contains `*`)
- Converts wildcard to regex pattern (e.g., `*Controller` → `^.*Controller$`)
- Matches against full type name including namespace
- Case-insensitive matching

**Substring Matching** (no wildcards)
- Falls back to `.Contains()` for simple searches
- Searches across FullName field
- Case-insensitive

## Usage Examples

### Recommended Patterns

| Pattern | Example | Finds |
|---------|---------|-------|
| Suffix | `*Controller` | Types ending with "Controller" (any namespace) |
| Contains | `*.Player*` | Types with "Player" anywhere in FullName |
| Namespace | `My.Namespace.*` | All types in specific namespace |
| Substring | `Controller` | Simple substring search (no wildcards) |

### Why Some Patterns Work Differently

Since wildcards match against FullName (e.g., `Company.Game.Player.PlayerController`):
- ❌ `Player*` won't find types unless they're in root namespace
- ✅ `Company.Game.Player.Player*` works for specific namespace
- ✅ `*Player*` or `Player` (no wildcards) - best for finding types containing "Player"

## Testing

Tested with various patterns:
- `*Controller` → 126 types ✅
- `*State` → 61 types ✅
- `*.Player*` → 141 types ✅
- `Player` (substring) → 151 types ✅
- Pagination with wildcards → Works correctly ✅

## Technical Details

- Regex pattern: `^{escaped_query_with_wildcards}$`
- Only creates regex when `*` detected in query
- Maintains existing pagination behavior via `CreatePaginatedResponse()`
- Compatible with existing MCP tool infrastructure