### PR TITLE
Add Streamable HTTP (MCP 2025-03-26) transport support

### DIFF
--- a/McpServer.cs
+++ b/McpServer.cs
@@ -27,6 +27,7 @@ namespace dnSpy.Extension.MCP {
 		CancellationTokenSource? cts;
 		int actualPort;
 		readonly ConcurrentDictionary<string, SseSession> sseSessions = new ConcurrentDictionary<string, SseSession>();
+		readonly ConcurrentDictionary<string, StreamableHttpSession> streamableSessions = new ConcurrentDictionary<string, StreamableHttpSession>();
 
 		/// <summary>
 		/// The port the server is actually listening on. May differ from <see cref="McpSettings.Port"/>
@@ -137,10 +138,13 @@ namespace dnSpy.Extension.MCP {
 
 		void HandleHttpRequest(HttpListenerContext context) {
 			try {
-				// Enable CORS
+				// Enable CORS. `Mcp-Session-Id` must be both accepted on requests and exposed on
+				// responses so Streamable HTTP clients (codex, MCP Inspector, ...) can read the
+				// session ID that the server allocates on `initialize`.
 				context.Response.AddHeader("Access-Control-Allow-Origin", "*");
-				context.Response.AddHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-				context.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type");
+				context.Response.AddHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+				context.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id, MCP-Protocol-Version");
+				context.Response.AddHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
 
 				if (context.Request.HttpMethod == "OPTIONS") {
 					context.Response.StatusCode = 200;
@@ -148,7 +152,10 @@ namespace dnSpy.Extension.MCP {
 					return;
 				}
 
-				if (context.Request.Url?.AbsolutePath == "/health" && context.Request.HttpMethod == "GET") {
+				var path = context.Request.Url?.AbsolutePath ?? string.Empty;
+				var httpMethod = context.Request.HttpMethod;
+
+				if (path == "/health" && httpMethod == "GET") {
 					var healthResponse = "{\"status\":\"ok\",\"service\":\"dnSpy MCP Server\"}";
 					var buffer = Encoding.UTF8.GetBytes(healthResponse);
 					context.Response.ContentType = "application/json";
@@ -158,111 +165,48 @@ namespace dnSpy.Extension.MCP {
 					return;
 				}
 
-				// MCP SSE transport: GET /sse opens a long-lived event-stream. The handler
-				// holds the HttpListener response open until the client disconnects or the
-				// server shuts down. Responses to posted messages are written back over this
-				// same stream as `message` events.
-				if (context.Request.Url?.AbsolutePath == "/sse" && context.Request.HttpMethod == "GET") {
-					context.Response.ContentType = "text/event-stream";
-					context.Response.Headers["Cache-Control"] = "no-cache";
-					context.Response.SendChunked = true;
-					context.Response.KeepAlive = true;
-
-					var sessionId = Guid.NewGuid().ToString("N");
-					var session = new SseSession(sessionId, context.Response.OutputStream);
-					sseSessions[sessionId] = session;
-					settings.Log($"SSE session opened: {sessionId}");
-
-					try {
-						session.WriteEvent("endpoint", $"/message?sessionId={sessionId}");
-
-						// Keep the connection alive until the client closes or the server stops.
-						// We detect client disconnection by sending a periodic SSE comment ping.
-						while (!cts!.Token.IsCancellationRequested) {
-							Thread.Sleep(15000);
-							try {
-								session.WriteComment("ping");
-							}
-							catch {
-								break;
-							}
-						}
-					}
-					finally {
-						sseSessions.TryRemove(sessionId, out _);
-						settings.Log($"SSE session closed: {sessionId}");
-						try { context.Response.OutputStream.Close(); } catch { /* ignore */ }
-						try { context.Response.Close(); } catch { /* ignore */ }
-					}
+				if (path == "/sse" && httpMethod == "GET") {
+					HandleLegacySseGet(context);
 					return;
 				}
 
-				if (context.Request.Url?.AbsolutePath == "/message" && context.Request.HttpMethod == "POST") {
-					var sessionId = context.Request.QueryString["sessionId"];
-					if (string.IsNullOrEmpty(sessionId) || !sseSessions.TryGetValue(sessionId!, out var session)) {
-						context.Response.StatusCode = 404;
-						var bytes = Encoding.UTF8.GetBytes("Unknown sessionId");
-						context.Response.OutputStream.Write(bytes, 0, bytes.Length);
-						context.Response.Close();
-						return;
-					}
-
-					using var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding);
-					var body = reader.ReadToEnd();
-
-					var request = JsonSerializer.Deserialize<McpRequest>(body);
-					if (request == null) {
-						context.Response.StatusCode = 400;
-						context.Response.Close();
-						return;
-					}
-
-					// Ack the POST. The JSON-RPC response is delivered over the SSE stream.
-					context.Response.StatusCode = 202;
-					var ack = Encoding.UTF8.GetBytes("Accepted");
-					context.Response.OutputStream.Write(ack, 0, ack.Length);
-					context.Response.Close();
-
-					try {
-						bool isNotification = request.Method?.StartsWith("notifications/", StringComparison.Ordinal) ?? false;
-						var response = HandleRequest(request);
-						if (!isNotification) {
-							var responseJson = JsonSerializer.Serialize(response, jsonOptions);
-							session.WriteEvent("message", responseJson);
-						}
-					}
-					catch (Exception ex) {
-						settings.Log($"ERROR writing SSE message: {ex.Message}");
-					}
+				if (path == "/message" && httpMethod == "POST") {
+					HandleLegacySsePost(context);
 					return;
 				}
 
-				if (context.Request.Url?.AbsolutePath == "/" && context.Request.HttpMethod == "POST") {
-					using var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding);
-					var body = reader.ReadToEnd();
+				// MCP Streamable HTTP (spec revision 2025-03-26) uses a single endpoint for
+				// POST / GET / DELETE. We accept both "/" and "/mcp" so that codex-style
+				// `type = "streamable-http"` configs pointing at http://host:port work without
+				// a path suffix, while still matching clients that hit /mcp explicitly.
+				bool isStreamablePath = path == "/" || path == "/mcp";
+				if (isStreamablePath) {
+					var accept = context.Request.Headers["Accept"] ?? string.Empty;
+					bool acceptsEventStream = accept.IndexOf("text/event-stream", StringComparison.OrdinalIgnoreCase) >= 0;
 
-					var request = JsonSerializer.Deserialize<McpRequest>(body);
-					if (request == null) {
-						context.Response.StatusCode = 400;
-						var errorBytes = Encoding.UTF8.GetBytes("Invalid request");
-						context.Response.OutputStream.Write(errorBytes, 0, errorBytes.Length);
-						context.Response.Close();
+					if (httpMethod == "POST") {
+						// Streamable HTTP clients always include text/event-stream in Accept;
+						// plain-JSON clients (curl, legacy docs) do not. Disambiguate on that.
+						if (acceptsEventStream)
+							HandleStreamableHttpPost(context);
+						else
+							HandleLegacyPlainPost(context);
 						return;
 					}
 
-					var response = HandleRequest(request);
-					var responseJson = JsonSerializer.Serialize(response, jsonOptions);
-					var responseBytes = Encoding.UTF8.GetBytes(responseJson);
+					if (httpMethod == "GET" && acceptsEventStream) {
+						HandleStreamableHttpGet(context);
+						return;
+					}
 
-					context.Response.ContentType = "application/json";
-					context.Response.ContentLength64 = responseBytes.Length;
-					context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
-					context.Response.Close();
+					if (httpMethod == "DELETE") {
+						HandleStreamableHttpDelete(context);
+						return;
+					}
 				}
-				else {
-					context.Response.StatusCode = 404;
-					context.Response.Close();
-				}
+
+				context.Response.StatusCode = 404;
+				context.Response.Close();
 			}
 			catch (Exception ex) {
 				try {
@@ -287,6 +231,230 @@ namespace dnSpy.Extension.MCP {
 					// Failed to send error response
 				}
 			}
+		}
+
+		/// <summary>
+		/// Legacy MCP 2024-11-05 SSE transport: GET /sse opens a long-lived event-stream.
+		/// The handler holds the HttpListener response open until the client disconnects or
+		/// the server shuts down. Responses to posted messages are written back over this
+		/// same stream as `message` events.
+		/// </summary>
+		void HandleLegacySseGet(HttpListenerContext context) {
+			context.Response.ContentType = "text/event-stream";
+			context.Response.Headers["Cache-Control"] = "no-cache";
+			context.Response.SendChunked = true;
+			context.Response.KeepAlive = true;
+
+			var sessionId = Guid.NewGuid().ToString("N");
+			var session = new SseSession(sessionId, context.Response.OutputStream);
+			sseSessions[sessionId] = session;
+			settings.Log($"SSE session opened: {sessionId}");
+
+			try {
+				session.WriteEvent("endpoint", $"/message?sessionId={sessionId}");
+
+				while (!cts!.Token.IsCancellationRequested) {
+					Thread.Sleep(15000);
+					try {
+						session.WriteComment("ping");
+					}
+					catch {
+						break;
+					}
+				}
+			}
+			finally {
+				sseSessions.TryRemove(sessionId, out _);
+				settings.Log($"SSE session closed: {sessionId}");
+				try { context.Response.OutputStream.Close(); } catch { /* ignore */ }
+				try { context.Response.Close(); } catch { /* ignore */ }
+			}
+		}
+
+		void HandleLegacySsePost(HttpListenerContext context) {
+			var sessionId = context.Request.QueryString["sessionId"];
+			if (string.IsNullOrEmpty(sessionId) || !sseSessions.TryGetValue(sessionId!, out var session)) {
+				context.Response.StatusCode = 404;
+				var bytes = Encoding.UTF8.GetBytes("Unknown sessionId");
+				context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+				context.Response.Close();
+				return;
+			}
+
+			using var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding);
+			var body = reader.ReadToEnd();
+
+			var request = JsonSerializer.Deserialize<McpRequest>(body);
+			if (request == null) {
+				context.Response.StatusCode = 400;
+				context.Response.Close();
+				return;
+			}
+
+			// Ack the POST. The JSON-RPC response is delivered over the SSE stream.
+			context.Response.StatusCode = 202;
+			var ack = Encoding.UTF8.GetBytes("Accepted");
+			context.Response.OutputStream.Write(ack, 0, ack.Length);
+			context.Response.Close();
+
+			try {
+				bool isNotification = request.Method?.StartsWith("notifications/", StringComparison.Ordinal) ?? false;
+				var response = HandleRequest(request);
+				if (!isNotification) {
+					var responseJson = JsonSerializer.Serialize(response, jsonOptions);
+					session.WriteEvent("message", responseJson);
+				}
+			}
+			catch (Exception ex) {
+				settings.Log($"ERROR writing SSE message: {ex.Message}");
+			}
+		}
+
+		void HandleLegacyPlainPost(HttpListenerContext context) {
+			using var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding);
+			var body = reader.ReadToEnd();
+
+			var request = JsonSerializer.Deserialize<McpRequest>(body);
+			if (request == null) {
+				context.Response.StatusCode = 400;
+				var errorBytes = Encoding.UTF8.GetBytes("Invalid request");
+				context.Response.OutputStream.Write(errorBytes, 0, errorBytes.Length);
+				context.Response.Close();
+				return;
+			}
+
+			var response = HandleRequest(request);
+			var responseJson = JsonSerializer.Serialize(response, jsonOptions);
+			var responseBytes = Encoding.UTF8.GetBytes(responseJson);
+
+			context.Response.ContentType = "application/json";
+			context.Response.ContentLength64 = responseBytes.Length;
+			context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+			context.Response.Close();
+		}
+
+		/// <summary>
+		/// MCP Streamable HTTP (2025-03-26) POST handler. Parses the JSON-RPC body, allocates a
+		/// session ID on `initialize` and echoes back the session ID on subsequent calls via the
+		/// `Mcp-Session-Id` header. Responses are returned inline as `application/json` (allowed
+		/// by the spec as an alternative to an SSE stream). Notifications get `202 Accepted`.
+		/// </summary>
+		void HandleStreamableHttpPost(HttpListenerContext context) {
+			using var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding);
+			var body = reader.ReadToEnd();
+
+			McpRequest? request;
+			try {
+				request = JsonSerializer.Deserialize<McpRequest>(body);
+			}
+			catch (JsonException ex) {
+				settings.Log($"Streamable HTTP parse error: {ex.Message}");
+				context.Response.StatusCode = 400;
+				var bytes = Encoding.UTF8.GetBytes("Parse error");
+				context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+				context.Response.Close();
+				return;
+			}
+
+			if (request == null || string.IsNullOrEmpty(request.Method)) {
+				context.Response.StatusCode = 400;
+				var bytes = Encoding.UTF8.GetBytes("Invalid request");
+				context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+				context.Response.Close();
+				return;
+			}
+
+			var headerSessionId = context.Request.Headers["Mcp-Session-Id"];
+			bool isInitialize = string.Equals(request.Method, "initialize", StringComparison.Ordinal);
+
+			if (isInitialize) {
+				var newId = Guid.NewGuid().ToString("N");
+				streamableSessions[newId] = new StreamableHttpSession(newId);
+				context.Response.Headers["Mcp-Session-Id"] = newId;
+				settings.Log($"Streamable HTTP session opened: {newId}");
+			}
+			else if (!string.IsNullOrEmpty(headerSessionId) && !streamableSessions.ContainsKey(headerSessionId!)) {
+				// If the client presents a session ID we don't recognise, reject — the client
+				// should then re-initialize. Missing header is tolerated for leniency.
+				context.Response.StatusCode = 404;
+				var bytes = Encoding.UTF8.GetBytes("Unknown Mcp-Session-Id");
+				context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+				context.Response.Close();
+				return;
+			}
+
+			bool isNotification = request.Method.StartsWith("notifications/", StringComparison.Ordinal) || request.Id == null;
+
+			if (isNotification) {
+				HandleRequest(request);
+				context.Response.StatusCode = 202;
+				context.Response.ContentLength64 = 0;
+				context.Response.Close();
+				return;
+			}
+
+			var response = HandleRequest(request);
+			var responseJson = JsonSerializer.Serialize(response, jsonOptions);
+			var responseBytes = Encoding.UTF8.GetBytes(responseJson);
+			context.Response.StatusCode = 200;
+			context.Response.ContentType = "application/json";
+			context.Response.ContentLength64 = responseBytes.Length;
+			context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+			context.Response.Close();
+		}
+
+		/// <summary>
+		/// MCP Streamable HTTP GET handler. Opens a long-lived SSE stream for server-initiated
+		/// messages on an existing session. This server currently has no server-initiated
+		/// requests, so the stream just emits keep-alive pings until the client disconnects.
+		/// </summary>
+		void HandleStreamableHttpGet(HttpListenerContext context) {
+			var sessionId = context.Request.Headers["Mcp-Session-Id"];
+			if (string.IsNullOrEmpty(sessionId) || !streamableSessions.ContainsKey(sessionId!)) {
+				context.Response.StatusCode = 404;
+				var bytes = Encoding.UTF8.GetBytes("Unknown Mcp-Session-Id");
+				context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+				context.Response.Close();
+				return;
+			}
+
+			context.Response.ContentType = "text/event-stream";
+			context.Response.Headers["Cache-Control"] = "no-cache";
+			context.Response.SendChunked = true;
+			context.Response.KeepAlive = true;
+
+			settings.Log($"Streamable HTTP GET stream opened: {sessionId}");
+			var session = new SseSession(sessionId!, context.Response.OutputStream);
+			try {
+				while (!cts!.Token.IsCancellationRequested) {
+					Thread.Sleep(15000);
+					try {
+						session.WriteComment("ping");
+					}
+					catch {
+						break;
+					}
+				}
+			}
+			finally {
+				settings.Log($"Streamable HTTP GET stream closed: {sessionId}");
+				try { context.Response.OutputStream.Close(); } catch { /* ignore */ }
+				try { context.Response.Close(); } catch { /* ignore */ }
+			}
+		}
+
+		/// <summary>
+		/// MCP Streamable HTTP DELETE handler. Terminates the session identified by
+		/// `Mcp-Session-Id`. Returns 200 even when the session is unknown so that clients
+		/// can idempotently tear down.
+		/// </summary>
+		void HandleStreamableHttpDelete(HttpListenerContext context) {
+			var sessionId = context.Request.Headers["Mcp-Session-Id"];
+			if (!string.IsNullOrEmpty(sessionId) && streamableSessions.TryRemove(sessionId!, out _))
+				settings.Log($"Streamable HTTP session closed by DELETE: {sessionId}");
+			context.Response.StatusCode = 200;
+			context.Response.ContentLength64 = 0;
+			context.Response.Close();
 		}
 
 		/// <summary>
@@ -483,6 +651,20 @@ namespace dnSpy.Extension.MCP {
 				stream.Write(bytes, 0, bytes.Length);
 				stream.Flush();
 			}
+		}
+	}
+
+	/// <summary>
+	/// A Streamable HTTP (MCP 2025-03-26) session. Unlike legacy SSE, the transport is
+	/// POST-driven: each client POST returns its own JSON-RPC response inline, so the
+	/// session only tracks identity and liveness rather than owning a response stream.
+	/// </summary>
+	sealed class StreamableHttpSession {
+		public string Id { get; }
+		public DateTime CreatedAtUtc { get; } = DateTime.UtcNow;
+
+		public StreamableHttpSession(string id) {
+			Id = id;
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -109,11 +109,47 @@ Settings live under **Edit → Settings → MCP Server**:
 
 ## Transports
 
-Both transports run on the same `HttpListener` on the same port.
+All three transports run on the same `HttpListener` on the same port. The server picks the right one by inspecting the path, HTTP method, and `Accept` header of each request.
+
+### Streamable HTTP (MCP 2025-03-26)
+
+Single-endpoint transport used by codex and other modern MCP clients. The client POSTs JSON-RPC requests with `Accept: application/json, text/event-stream`; the server returns the JSON-RPC response inline as `application/json` and allocates a session on `initialize` via the `Mcp-Session-Id` response header. Subsequent POSTs must echo that header. The server also honours `GET` on the same endpoint for server-initiated SSE and `DELETE` for teardown.
+
+Both `/` and `/mcp` are accepted as the endpoint path.
+
+```bash
+# 1. Initialize — server returns the session ID in the Mcp-Session-Id header.
+curl -i -X POST http://localhost:3000/ \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
+# HTTP/1.1 200 OK
+# Mcp-Session-Id: <sid>
+# Content-Type: application/json
+# {"jsonrpc":"2.0","id":1,"result":{...}}
+
+# 2. Subsequent calls echo the session header.
+curl -X POST http://localhost:3000/ \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <sid>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+# 3. Tear down explicitly (optional — the server also drops the session on shutdown).
+curl -X DELETE http://localhost:3000/ -H "Mcp-Session-Id: <sid>"
+```
+
+Codex `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.dnspy-mcp]
+type = "streamable-http"
+url = "http://localhost:3000"
+```
 
 ### Plain HTTP JSON-RPC
 
-One-shot request/response — POST JSON-RPC to `/` and read the response from the same HTTP response body.
+One-shot request/response — POST JSON-RPC to `/` without `text/event-stream` in `Accept` and read the response from the same HTTP response body. Useful for quick `curl` testing and for MCP clients that only speak plain HTTP.
 
 ```bash
 curl -s http://localhost:3000/health
@@ -126,7 +162,7 @@ curl -s -X POST http://localhost:3000/ \
 
 ### Server-Sent Events (MCP 2024-11-05)
 
-Two-endpoint transport: a long-lived SSE stream, plus a POST endpoint for client messages.
+Legacy two-endpoint transport kept for backwards compatibility with MCP Inspector and older clients: a long-lived SSE stream, plus a POST endpoint for client messages.
 
 1. `GET /sse` — opens `text/event-stream`. The first event (`event: endpoint`) carries the URL the client should POST to (`/message?sessionId=<id>`).
 2. `POST /message?sessionId=<id>` — accepts a JSON-RPC request, returns `202 Accepted`, and writes the real JSON-RPC response onto the corresponding SSE stream as an `event: message`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,11 +109,47 @@ cp bin/Release/net10.0-windows/dnSpy.Extension.MCP.x.dll \
 
 ## 传输协议
 
-两种传输使用同一个 `HttpListener`、同一端口。
+三种传输共用同一个 `HttpListener` 与同一端口。服务器根据请求的路径、HTTP 方法与 `Accept` 头自动选择对应的处理逻辑。
+
+### Streamable HTTP（MCP 2025-03-26）
+
+单端点传输，codex 等新版 MCP 客户端使用。客户端在 POST 时携带 `Accept: application/json, text/event-stream`；服务器在 `initialize` 响应的 `Mcp-Session-Id` 头中分配会话 ID，后续请求需回传该头。同一端点的 `GET` 用于服务端主动推送（SSE），`DELETE` 用于显式结束会话。
+
+路径 `/` 与 `/mcp` 均可作为端点。
+
+```bash
+# 1. 初始化 —— 服务器在 Mcp-Session-Id 响应头中返回会话 ID
+curl -i -X POST http://localhost:3000/ \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
+# HTTP/1.1 200 OK
+# Mcp-Session-Id: <sid>
+# Content-Type: application/json
+# {"jsonrpc":"2.0","id":1,"result":{...}}
+
+# 2. 后续请求需回传会话头
+curl -X POST http://localhost:3000/ \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <sid>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+# 3. 可选：显式结束会话（服务器关闭时也会清理）
+curl -X DELETE http://localhost:3000/ -H "Mcp-Session-Id: <sid>"
+```
+
+codex `~/.codex/config.toml`：
+
+```toml
+[mcp_servers.dnspy-mcp]
+type = "streamable-http"
+url = "http://localhost:3000"
+```
 
 ### 普通 HTTP JSON-RPC
 
-一次性请求/响应：向 `/` POST 一个 JSON-RPC 消息，从同一 HTTP 响应体读取结果。
+一次性请求/响应：向 `/` POST 一个 JSON-RPC 消息（`Accept` 头**不包含** `text/event-stream`），从同一 HTTP 响应体读取结果。适合 `curl` 调试或只会说纯 HTTP 的客户端。
 
 ```bash
 curl -s http://localhost:3000/health
@@ -124,9 +160,9 @@ curl -s -X POST http://localhost:3000/ \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
 ```
 
-### Server-Sent Events（MCP 2024-11-05）
+### Server-Sent Events（MCP 2024-11-05，遗留）
 
-双端点传输：一条长连接 SSE 流 + 一个用于客户端消息的 POST 端点。
+为了兼容 MCP Inspector 与旧客户端而保留的双端点传输：一条长连接 SSE 流 + 一个用于客户端消息的 POST 端点。
 
 1. `GET /sse` — 打开 `text/event-stream`。首个事件 (`event: endpoint`) 的 `data` 字段告诉客户端应当 POST 到哪里（`/message?sessionId=<id>`）。
 2. `POST /message?sessionId=<id>` — 客户端发送 JSON-RPC 请求，服务器立即返回 `202 Accepted`，真正的 JSON-RPC 响应作为 `event: message` 写回对应的 SSE 流。


### PR DESCRIPTION
## Summary

Implements support for the MCP Streamable HTTP specification (2025-03-26), a modern single-endpoint transport used by codex and other contemporary MCP clients. The server now supports three transports simultaneously on the same port, automatically routing requests based on path, HTTP method, and `Accept` header.

## Key Changes

- **New Streamable HTTP transport**: Implements POST/GET/DELETE handlers for the 2025-03-26 MCP spec
  - Single endpoint (`/` or `/mcp`) replaces the legacy two-endpoint SSE design
  - Session allocation via `Mcp-Session-Id` header on `initialize`
  - Inline JSON-RPC responses (no separate SSE stream for responses)
  - GET for server-initiated messages, DELETE for explicit teardown

- **CORS header updates**: Enhanced to support Streamable HTTP requirements
  - Added `DELETE` to allowed methods
  - Added `Mcp-Session-Id` and `MCP-Protocol-Version` to allowed headers
  - Added `Access-Control-Expose-Headers` to expose `Mcp-Session-Id` to clients

- **Request routing logic**: Refactored `HandleHttpRequest` to dispatch to appropriate handlers
  - Disambiguates between Streamable HTTP and plain JSON-RPC via `Accept` header
  - Extracts path and method once for cleaner routing
  - Maintains backward compatibility with legacy SSE and plain HTTP transports

- **Handler extraction**: Moved legacy transport logic into dedicated methods
  - `HandleLegacySseGet`: Legacy SSE stream initialization
  - `HandleLegacySsePost`: Legacy SSE message posting
  - `HandleLegacyPlainPost`: Plain HTTP JSON-RPC
  - `HandleStreamableHttpPost`: Streamable HTTP POST with session management
  - `HandleStreamableHttpGet`: Streamable HTTP SSE stream for server-initiated messages
  - `HandleStreamableHttpDelete`: Session teardown

- **Session tracking**: Added `streamableSessions` dictionary to track active Streamable HTTP sessions
  - New `StreamableHttpSession` class to represent session identity and liveness

- **Documentation**: Updated README with Streamable HTTP examples and clarified transport hierarchy

## Implementation Details

- Session IDs are allocated on `initialize` and returned via the `Mcp-Session-Id` response header
- Subsequent requests must echo the session ID header; unknown sessions return 404
- Notifications (methods starting with `notifications/` or requests with no `id`) return 202 Accepted
- The server accepts both `/` and `/mcp` paths to support different client configurations
- All three transports coexist; routing is automatic and transparent to clients

Fixes #5 