### PR TITLE
Add IL view/edit/save tools so AI clients can patch bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ packages/
 *.pdb
 !dnSpy.Extension.MCP.x.dll
 
+# Fixture artifacts produced by tests/fixtures/run-tests.ps1
+tests/fixtures/bin/
+tests/fixtures/obj/
+tests/fixtures/*.bak
+tests/fixtures/TestIL.dll.*.bak
+
 # OS files
 Thumbs.db
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository overview
+
+This is the **dnSpy MCP extension** — a standalone git repo that is cloned *into* a [dnSpyEx](https://github.com/dnSpyEx/dnSpy) checkout at `Extensions/dnSpy.Extension.MCP/`. It is a dnSpy extension (MEF-loaded `*.x.dll`) that runs an HTTP server inside the dnSpy process and exposes 15 assembly-analysis / decompilation / IL-editing tools and 6 embedded BepInEx docs to AI assistants over Model Context Protocol (JSON-RPC 2.0).
+
+## Build
+
+**Prerequisite: a dnSpyEx checkout with submodules initialized.** The csproj has two `ProjectReference`s (`../../dnSpy/dnSpy.Contracts.DnSpy/` and `../../dnSpy/dnSpy.Contracts.Logic/`) and imports `../../DnSpyCommon.props`. Without the parent checkout and `git submodule update --init --recursive` in it, restore fails.
+
+Target frameworks are inherited from `../../DnSpyCommon.props` (currently `net48;net10.0-windows`). Don't pin TFMs in this csproj — let the common props drive it.
+
+```bash
+dotnet build -c Release                     # both TFMs (~3s; only the two Contracts refs)
+dotnet build -c Debug -f net48              # single-TFM iteration
+dotnet build -c Debug -f net10.0-windows
+```
+
+Output: `bin/<Config>/<TFM>/dnSpy.Extension.MCP.x.dll`. The **`.x` suffix is mandatory** — dnSpy's extension loader skips files without it. Deploy by copying the DLL into `<dnSpy-Install>\bin\Extensions\dnSpy.Extension.MCP\` — the folder name must match the DLL stem. Placing the DLL one level up under `bin\Extensions\` silently fails.
+
+There is no test suite. CI (`.github/workflows/build.yml`) just builds both TFMs; `release.yml` runs the parent repo's `build.ps1` and ships all-in-one zips on `v*.*.*` tags.
+
+## Architecture
+
+- **`TheExtension.cs`** — `[ExportExtension]` MEF entry. Starts the server on `ExtensionEvent.Loaded` (if enabled), stops it on `AppExit`.
+- **`McpServer.cs`** — single `HttpListener` on **both TFMs**. Kestrel was intentionally dropped: dnSpy's self-contained .NET bundle does not include ASP.NET Core, so referencing `Microsoft.AspNetCore.*` causes a silent `TypeLoadException` during MEF composition and the `IExtension` part never instantiates. Do not reintroduce Kestrel or `#if NET` branches here. The server exposes four routes on one port:
+  - `GET /health` — liveness probe
+  - `POST /` — plain HTTP JSON-RPC (one-shot request/response)
+  - `GET /sse` — opens a long-lived `text/event-stream`; first event carries the `/message?sessionId=<id>` URL
+  - `POST /message?sessionId=<id>` — accepts JSON-RPC, returns `202 Accepted`, writes the real response back over the SSE stream
+  - Port fallback: tries `Port..Port+19` and logs which one it bound to. Clients should read the resolved port from the log.
+- **`McpTools.cs` / `McpTools.IL.cs`** — the 15 tools, wrapping `IDocumentTreeView` (loaded-assembly enumeration), `IDecompilerService` (decompilation), and dnlib's `CilBody` (IL view/edit). `McpTools` is a `sealed partial class` split across two files: `McpTools.cs` holds the MEF export, tool schemas, dispatch switch, and shared helpers (`FindAssemblyByName`, `FindTypeInAssembly`, `FindMethod`, cursor codec); `McpTools.IL.cs` holds the IL view/patch/save handlers and the tagged-operand renderer/parser. List-returning tools use **opaque base64 cursors** (see `EncodeCursor` / `DecodeCursor`) with default page size **10** to stay within AI token budgets. Follow this pattern when adding list tools.
+- **`ExecuteTool` marshals every handler onto the WPF UI thread via `InvokeOnUiThread`.** `IDocumentTreeView` nodes are `DispatcherObject` instances — reading the tree from an HTTP worker throws "calling thread cannot access this object" the moment a user-loaded assembly is indexed. Handlers that already marshal explicitly (patch, revert, save) double-wrap harmlessly because `InvokeOnUiThread` short-circuits when `CheckAccess()` is true.
+- **`McpProtocol.cs`** — JSON-RPC 2.0 + MCP DTOs. Uses `System.Text.Json` on both TFMs (BCL on net10, NuGet on net48). `jsonOptions` in `McpServer` writes with `JsonIgnoreCondition.WhenWritingNull` — MCP requires null-stripped payloads.
+- **`McpSettings.cs`** — two classes: `McpSettings` (public `ViewModelBase`, the imported service) and `McpSettingsImpl : McpSettings` (the `[Export(typeof(McpSettings))]` impl). The impl persists via `ISettingsService` under a **hardcoded settings GUID** — never change it, or every user's saved settings reset. Property changes drive server start/stop, so toggling "Enable Server" in the UI takes effect without a restart.
+- **`McpSettingsPage.cs` / `McpSettingsControl.xaml*`** — WPF settings page wired into dnSpy via `IAppSettingsPageProvider`.
+- **`BepInExResources.cs`** — embedded markdown docs served via MCP `resources/list` / `resources/read`. Self-contained, no network.
+
+### Conventions specific to this extension
+
+- **MEF everywhere.** New services use `[Export(typeof(T))]` + `[ImportingConstructor]`. Never `new` up `McpServer`, `McpSettings`, `McpTools`, or `BepInExResources` — let the container wire them.
+- **JSON-RPC error codes.** In `McpServer.HandleRequest`, `ArgumentException` → `-32602` (invalid params), everything else → `-32603` (internal error). Throw `ArgumentException` from tool handlers for bad user input so clients get the right code.
+- **No `#if` TFM branches.** The codebase is currently single-stack (HttpListener + System.Text.Json on both TFMs). The only TFM-conditional item is the `System.Text.Json` `PackageReference` in the csproj under `IsDotNetFramework`.
+- **`McpSettings.Log` mirrors to disk.** The on-disk log at `McpSettings.LogFilePath` is the authoritative record — the in-memory `ObservableCollection` is best-effort for the UI only, and can drop entries when the dispatcher isn't yet up. `LogFilePath` is currently hardcoded (`D:\dnspy-mcp.log`); if you port this to another machine, expect the log to go missing silently unless you change the path.
+- **UI-thread marshaling for log.** `Log()` uses `Application.Current.Dispatcher` because `LogMessages` is bound to WPF. Don't bypass it.
+
+### IL editing (list_methods / get_method_il / patch_method_il / revert_method_il / save_assembly)
+
+- **Method identification.** Names alone aren't unique — pass `parameter_types` (array of `FullName`s) or the `method_token` (dnlib `MDToken.Raw`) returned by `list_methods` / `get_type_info`. `FindMethod` throws `ArgumentException` with a candidate-signature list on ambiguity so the AI can retry.
+- **Operand grammar is tagged** (`int:`, `str:`, `method:`, `field:`, `type:`, `token:method:|field:|type:`, `label:`, `switch:[…]`, `local:`, `arg:`, `int8:`, `uint8:`, `long:`, `float:`, `double:`). The renderer and parser in `McpTools.IL.cs` share this grammar — keep them symmetric when adding kinds. `InlineSig` / `calli` is unsupported.
+- **Edit semantics.** `replace` mutates the existing `Instruction` object in place so branch / switch operands that reference it still resolve correctly. `insert` creates a new `Instruction` and places it before the target index (or appends if index == Count). `delete` removes by reference. All edit indices refer to the pre-batch state — `ResolveEdit` resolves them to `Instruction` references before applying so later inserts/deletes don't shift them.
+- **Snapshots preserve identity.** `CilBodySnapshot` captures `(Instruction reference, OpCode, Operand)` per instruction plus the ordered list. `revert_method_il` un-mutates each `Instruction` back to its snapshotted (OpCode, Operand) and re-adds them in order — this is mandatory because a reference-only snapshot would be poisoned by the in-place `replace` mutation. `Instruction[]` switch operands are cloned at snapshot time for the same reason.
+- **Save uses `NativeWrite` for `ModuleDefMD`, `Write` for everything else.** Plain `Write` on a module that was loaded from disk drops native stubs, Win32 resources, delay-loaded imports, and mixed-mode metadata; `NativeModuleWriterOptions(md, optimizeImageSize: true)` preserves them. Before writing, memory-mapped I/O is disabled on every `IDsDocument` whose filename matches the target (case-insensitive) via the public `peImage as dnlib.PE.IInternalPEImage` cast — `dnSpy.AsmEditor`'s `IMmapDisabler` is internal so we inline the one-liner. GAC paths are refused via `GacInfo.IsGacPath`.
+- **Backup-then-overwrite on same-path saves.** When `output_path` is omitted (or equals the original location), `save_assembly` copies the existing file to `<target>.<yyyyMMdd-HHmmss>.bak` before writing. Side-path saves leave the original untouched and return `backup_path = null`.
+- **dnSpy's in-memory tree is NOT refreshed after save.** The `ModuleDef` our patches live in is still the pre-patch one in memory; the user has to reopen the assembly in dnSpy to see saved-to-disk state. This is deliberate — refreshing would require re-composing tabs/nodes under AsmEditor internals we don't reference.
+- **No Ctrl+Z integration.** `patch_method_il` does not route through dnSpy's `IUndoCommandService` (it's internal to AsmEditor). Use `revert_method_il` for undo within an MCP session; the snapshot is dropped after revert or after a successful save.
+
+### Test fixture (`tests/fixtures/`)
+
+- `TestIL.cs` + `TestIL.csproj` — a tiny netstandard2.0 assembly covering overloads, constant/string/branch/field/type operands. Checked in; the built `TestIL.dll` is **not** (see `.gitignore`).
+- `build-fixture.ps1` — `dotnet build` wrapper that emits `bin/TestIL.dll` and prints its SHA256.
+- `run-tests.ps1` — end-to-end driver. Builds the fixture and the extension, deploys the `.x.dll` into dnSpy's Extensions folder, sets `Port=3100` in `%APPDATA%\dnSpy\dnSpy.xml` (because WSL's `wslrelay.exe` commonly holds 3000 even though our `TcpListener` probe reports it free), launches dnSpy with the fixture as CLI arg, polls `list_assemblies` until `TestIL` appears, then walks through list_methods / decompile_method / get_method_il / patch_method_il / revert_method_il / save_assembly with SHA256 and behavioural asserts (a spawned PowerShell loads the saved DLL and invokes `AddOne(10)` to confirm the +1 → +41 patch took effect on disk).
+- The extension csproj sets `<DefaultItemExcludes>$(DefaultItemExcludes);tests/**</DefaultItemExcludes>` so the fixture's generated `AssemblyInfo.cs` doesn't get pulled into the extension build.
+
+## Git
+
+This repo is tracked independently from the parent dnSpy checkout. Work happens on `main`. Releases are driven by `v*.*.*` tags.

--- a/McpTools.IL.cs
+++ b/McpTools.IL.cs
@@ -1,0 +1,980 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Windows;
+using dnlib.DotNet;
+using dnlib.DotNet.Emit;
+
+namespace dnSpy.Extension.MCP
+{
+    // IL view / patch / save handlers. Lives as a partial so the MEF export + dispatch switch
+    // stay in McpTools.cs; this file is just handlers + IL helpers.
+    sealed partial class McpTools
+    {
+        // Snapshot store for revert_method_il. Populated lazily on first patch of a method.
+        readonly Dictionary<uint, CilBodySnapshot> ilSnapshots = new Dictionary<uint, CilBodySnapshot>();
+
+        // Serializes concurrent write ops (patch, revert, save) across HTTP clients. Reads do not
+        // take this lock — they run on HTTP threads like every other read handler. Writes also
+        // marshal through Application.Current.Dispatcher.Invoke to synchronize with any open
+        // AsmEditor Edit-Method-Body dialog (which mutates Body.Instructions on the UI thread).
+        readonly object ilEditLock = new object();
+
+        /// <summary>
+        /// Dispatches <paramref name="action"/> to the WPF UI thread if one exists, otherwise
+        /// runs it inline. Used for any handler that mutates dnlib state (<c>Body.Instructions</c>
+        /// lists, <c>ExceptionHandlers</c>, etc.) so we don't race AsmEditor's own UI-thread edits.
+        /// </summary>
+        T InvokeOnUiThread<T>(Func<T> action)
+        {
+            var app = Application.Current;
+            var dispatcher = app?.Dispatcher;
+            if (dispatcher == null || dispatcher.HasShutdownStarted || dispatcher.CheckAccess())
+                return action();
+            return dispatcher.Invoke(action);
+        }
+
+        // ---------- list_methods ----------
+
+        CallToolResult ListMethods(Dictionary<string, object>? arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentException("Arguments required");
+            if (!arguments.TryGetValue("assembly_name", out var assemblyNameObj))
+                throw new ArgumentException("assembly_name is required");
+            if (!arguments.TryGetValue("type_full_name", out var typeNameObj))
+                throw new ArgumentException("type_full_name is required");
+
+            var assemblyName = assemblyNameObj.ToString() ?? string.Empty;
+            var typeFullName = typeNameObj.ToString() ?? string.Empty;
+
+            string? cursor = null;
+            if (arguments.TryGetValue("cursor", out var cursorObj))
+                cursor = cursorObj?.ToString();
+
+            var (offset, pageSize) = DecodeCursor(cursor);
+
+            // Marshal to the UI thread: IDocumentTreeView nodes are DispatcherObjects and
+            // throw "calling thread cannot access this object" when touched from an HTTP thread
+            // during / shortly after a tree mutation (e.g. the assembly we loaded via CLI arg).
+            return InvokeOnUiThread(() =>
+            {
+                var assembly = FindAssemblyByName(assemblyName);
+                if (assembly == null)
+                    throw new ArgumentException($"Assembly not found: {assemblyName}");
+                var type = FindTypeInAssembly(assembly, typeFullName);
+                if (type == null)
+                    throw new ArgumentException($"Type not found: {typeFullName}");
+
+                var methods = type.Methods.Select(m => new
+                {
+                    name = m.Name.String,
+                    token = m.MDToken.Raw,
+                    signature = m.FullName,
+                    return_type = m.ReturnType?.FullName ?? "void",
+                    parameter_types = m.MethodSig == null
+                        ? new List<string>()
+                        : m.MethodSig.Params.Select(t => t?.FullName ?? "?").ToList(),
+                    parameters = m.Parameters
+                        .Where(p => !p.IsHiddenThisParameter)
+                        .Select(p => new { name = p.Name, type = p.Type?.FullName ?? "?" })
+                        .ToList(),
+                    is_static = m.IsStatic,
+                    is_virtual = m.IsVirtual,
+                    is_abstract = m.IsAbstract,
+                    has_body = m.HasBody
+                }).ToList();
+
+                return CreatePaginatedResponse(methods, offset, pageSize);
+            });
+        }
+
+        // ---------- get_method_il ----------
+
+        CallToolResult GetMethodIL(Dictionary<string, object>? arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentException("Arguments required");
+            if (!arguments.TryGetValue("assembly_name", out var assemblyNameObj))
+                throw new ArgumentException("assembly_name is required");
+            if (!arguments.TryGetValue("type_full_name", out var typeNameObj))
+                throw new ArgumentException("type_full_name is required");
+            if (!arguments.TryGetValue("method_name", out var methodNameObj))
+                throw new ArgumentException("method_name is required");
+
+            var assemblyName = assemblyNameObj.ToString() ?? string.Empty;
+            var typeFullName = typeNameObj.ToString() ?? string.Empty;
+            var methodName = methodNameObj.ToString() ?? string.Empty;
+
+            var parameterTypes = ReadStringArray(arguments, "parameter_types");
+            var methodToken = ReadOptionalUInt(arguments, "method_token");
+
+            return InvokeOnUiThread(() =>
+            {
+                var assembly = FindAssemblyByName(assemblyName);
+                if (assembly == null)
+                    throw new ArgumentException($"Assembly not found: {assemblyName}");
+                var type = FindTypeInAssembly(assembly, typeFullName);
+                if (type == null)
+                    throw new ArgumentException($"Type not found: {typeFullName}");
+
+                var method = FindMethod(type, methodName, parameterTypes, methodToken);
+                if (!method.HasBody || method.Body == null)
+                    throw new ArgumentException($"Method {DescribeSignature(method)} has no IL body (abstract / extern / P/Invoke).");
+
+                var body = method.Body;
+                body.UpdateInstructionOffsets();
+
+                var result = SerializeBody(method, body);
+                var json = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+                return new CallToolResult
+                {
+                    Content = new List<ToolContent> {
+                        new ToolContent { Text = json }
+                    }
+                };
+            });
+        }
+
+        // ---------- patch_method_il ----------
+
+        CallToolResult PatchMethodIL(Dictionary<string, object>? arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentException("Arguments required");
+            if (!arguments.TryGetValue("assembly_name", out var assemblyNameObj))
+                throw new ArgumentException("assembly_name is required");
+            if (!arguments.TryGetValue("type_full_name", out var typeNameObj))
+                throw new ArgumentException("type_full_name is required");
+            if (!arguments.TryGetValue("method_name", out var methodNameObj))
+                throw new ArgumentException("method_name is required");
+            if (!arguments.TryGetValue("edits", out var editsObj))
+                throw new ArgumentException("edits is required");
+
+            var assemblyName = assemblyNameObj.ToString() ?? string.Empty;
+            var typeFullName = typeNameObj.ToString() ?? string.Empty;
+            var methodName = methodNameObj.ToString() ?? string.Empty;
+            var parameterTypes = ReadStringArray(arguments, "parameter_types");
+            var methodToken = ReadOptionalUInt(arguments, "method_token");
+            var optimizeMacros = ReadOptionalBool(arguments, "optimize_macros") ?? false;
+
+            var edits = ParseEditsList(editsObj);
+
+            return InvokeOnUiThread(() =>
+            {
+                lock (ilEditLock)
+                {
+                    var assembly = FindAssemblyByName(assemblyName);
+                    if (assembly == null)
+                        throw new ArgumentException($"Assembly not found: {assemblyName}");
+                    var type = FindTypeInAssembly(assembly, typeFullName);
+                    if (type == null)
+                        throw new ArgumentException($"Type not found: {typeFullName}");
+
+                    var method = FindMethod(type, methodName, parameterTypes, methodToken);
+                    if (!method.HasBody || method.Body == null)
+                        throw new ArgumentException($"Method {DescribeSignature(method)} has no IL body.");
+                    var body = method.Body;
+                    var module = method.Module ?? assembly.ManifestModule;
+                    if (module == null)
+                        throw new ArgumentException("Cannot resolve owning module for method");
+
+                    // Snapshot on first patch so revert_method_il can undo.
+                    if (!ilSnapshots.ContainsKey(method.MDToken.Raw))
+                        ilSnapshots[method.MDToken.Raw] = Snapshot(body);
+
+                    // Resolve all edits against the pre-batch instruction list (by reference,
+                    // so inserts/deletes don't shift resolutions).
+                    var originalList = body.Instructions.ToList();
+                    var importer = new Importer(module, ImporterOptions.TryToUseDefs);
+                    var resolved = edits.Select(e => ResolveEdit(e, originalList, body, method, importer)).ToList();
+
+                    // Apply in order. For replace, mutate the existing Instruction so branch/switch
+                    // targets that reference it still resolve correctly.
+                    foreach (var e in resolved)
+                    {
+                        switch (e.Op)
+                        {
+                            case "replace":
+                                if (e.Target == null)
+                                    throw new ArgumentException($"replace index {e.Index} out of range");
+                                e.Target.OpCode = e.NewOpCode!;
+                                e.Target.Operand = e.NewOperand;
+                                break;
+                            case "insert":
+                                var newInstr = new Instruction(e.NewOpCode!) { Operand = e.NewOperand };
+                                if (e.Target == null)
+                                    body.Instructions.Add(newInstr);  // index == Count → append
+                                else
+                                {
+                                    var idx = body.Instructions.IndexOf(e.Target);
+                                    if (idx < 0)
+                                        throw new ArgumentException("insert target no longer in body (was it deleted earlier in this batch?)");
+                                    body.Instructions.Insert(idx, newInstr);
+                                }
+                                break;
+                            case "delete":
+                                if (e.Target == null || !body.Instructions.Remove(e.Target))
+                                    throw new ArgumentException($"delete index {e.Index} out of range or already removed");
+                                break;
+                            case "set_init_locals":
+                                body.InitLocals = e.BoolValue ?? body.InitLocals;
+                                break;
+                            default:
+                                throw new ArgumentException($"Unknown edit op: {e.Op}");
+                        }
+                    }
+
+                    if (optimizeMacros)
+                        body.Instructions.OptimizeMacros();
+
+                    body.UpdateInstructionOffsets();
+
+                    var projection = SerializeBody(method, body);
+                    projection["edits_applied"] = resolved.Count;
+                    var json = JsonSerializer.Serialize(projection, new JsonSerializerOptions { WriteIndented = true });
+                    return new CallToolResult
+                    {
+                        Content = new List<ToolContent> {
+                            new ToolContent { Text = json }
+                        }
+                    };
+                }
+            });
+        }
+
+        // ---------- revert_method_il ----------
+
+        CallToolResult RevertMethodIL(Dictionary<string, object>? arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentException("Arguments required");
+            if (!arguments.TryGetValue("assembly_name", out var assemblyNameObj))
+                throw new ArgumentException("assembly_name is required");
+            if (!arguments.TryGetValue("type_full_name", out var typeNameObj))
+                throw new ArgumentException("type_full_name is required");
+            if (!arguments.TryGetValue("method_name", out var methodNameObj))
+                throw new ArgumentException("method_name is required");
+
+            var assemblyName = assemblyNameObj.ToString() ?? string.Empty;
+            var typeFullName = typeNameObj.ToString() ?? string.Empty;
+            var methodName = methodNameObj.ToString() ?? string.Empty;
+            var parameterTypes = ReadStringArray(arguments, "parameter_types");
+            var methodToken = ReadOptionalUInt(arguments, "method_token");
+
+            return InvokeOnUiThread(() =>
+            {
+                lock (ilEditLock)
+                {
+                    var assembly = FindAssemblyByName(assemblyName);
+                    if (assembly == null)
+                        throw new ArgumentException($"Assembly not found: {assemblyName}");
+                    var type = FindTypeInAssembly(assembly, typeFullName);
+                    if (type == null)
+                        throw new ArgumentException($"Type not found: {typeFullName}");
+
+                    var method = FindMethod(type, methodName, parameterTypes, methodToken);
+                    if (!ilSnapshots.TryGetValue(method.MDToken.Raw, out var snap))
+                        throw new ArgumentException($"No pending patch to revert for {DescribeSignature(method)}");
+                    if (!method.HasBody || method.Body == null)
+                        throw new ArgumentException($"Method {DescribeSignature(method)} has no IL body anymore.");
+                    var body = method.Body;
+
+                    body.Instructions.Clear();
+                    foreach (var s in snap.Instructions)
+                    {
+                        // Un-mutate the Instruction object back to its pre-patch state — this
+                        // preserves reference identity for branch/switch operands elsewhere in
+                        // the body so targets that were pointing at this instruction still do.
+                        s.Instr.OpCode = s.OpCode;
+                        s.Instr.Operand = s.Operand;
+                        body.Instructions.Add(s.Instr);
+                    }
+                    body.Variables.Clear();
+                    foreach (var v in snap.Variables) body.Variables.Add(v);
+                    body.ExceptionHandlers.Clear();
+                    foreach (var eh in snap.ExceptionHandlers) body.ExceptionHandlers.Add(eh);
+                    body.MaxStack = snap.MaxStack;
+                    body.InitLocals = snap.InitLocals;
+                    body.KeepOldMaxStack = snap.KeepOldMaxStack;
+                    body.UpdateInstructionOffsets();
+
+                    ilSnapshots.Remove(method.MDToken.Raw);
+
+                    var projection = SerializeBody(method, body);
+                    projection["reverted"] = true;
+                    var json = JsonSerializer.Serialize(projection, new JsonSerializerOptions { WriteIndented = true });
+                    return new CallToolResult
+                    {
+                        Content = new List<ToolContent> {
+                            new ToolContent { Text = json }
+                        }
+                    };
+                }
+            });
+        }
+
+        // ---------- snapshot helper ----------
+
+        static CilBodySnapshot Snapshot(CilBody body) => new CilBodySnapshot
+        {
+            Instructions = body.Instructions.Select(i => new InstructionSnapshot
+            {
+                Instr = i,
+                OpCode = i.OpCode,
+                // For switch, the operand is an Instruction[] — clone it so a post-snapshot
+                // in-place mutation of the array won't leak into the snapshot.
+                Operand = i.Operand is Instruction[] arr ? (object)arr.ToArray() : i.Operand
+            }).ToList(),
+            Variables = body.Variables.ToList(),
+            ExceptionHandlers = body.ExceptionHandlers.ToList(),
+            MaxStack = body.MaxStack,
+            InitLocals = body.InitLocals,
+            KeepOldMaxStack = body.KeepOldMaxStack
+        };
+
+        // ---------- save_assembly ----------
+
+        CallToolResult SaveAssembly(Dictionary<string, object>? arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentException("Arguments required");
+            if (!arguments.TryGetValue("assembly_name", out var assemblyNameObj))
+                throw new ArgumentException("assembly_name is required");
+            var assemblyName = assemblyNameObj.ToString() ?? string.Empty;
+
+            string? outputPath = null;
+            if (arguments.TryGetValue("output_path", out var opObj) && opObj != null)
+            {
+                outputPath = opObj.ToString();
+                if (string.IsNullOrWhiteSpace(outputPath))
+                    outputPath = null;
+            }
+
+            return InvokeOnUiThread(() =>
+            {
+                lock (ilEditLock)
+                {
+                    var assembly = FindAssemblyByName(assemblyName);
+                    if (assembly == null)
+                        throw new ArgumentException($"Assembly not found: {assemblyName}");
+                    var module = assembly.ManifestModule ?? assembly.Modules.FirstOrDefault();
+                    if (module == null)
+                        throw new ArgumentException($"Assembly {assemblyName} has no modules");
+
+                    // Locate the loaded document for this module's filename so we can read
+                    // the on-disk Location and disable its memory-mapped file handle.
+                    var ownerDoc = documentTreeView.DocumentService.GetDocuments()
+                        .FirstOrDefault(d => d.AssemblyDef == assembly)
+                        ?? documentTreeView.DocumentService.GetDocuments()
+                            .FirstOrDefault(d => d.ModuleDef == module);
+
+                    var originalPath = ownerDoc?.Filename;
+                    if (string.IsNullOrWhiteSpace(outputPath))
+                    {
+                        if (string.IsNullOrWhiteSpace(originalPath))
+                            throw new ArgumentException($"Assembly {assemblyName} has no on-disk location; pass output_path explicitly.");
+                        outputPath = originalPath;
+                    }
+
+                    outputPath = System.IO.Path.GetFullPath(outputPath!);
+
+                    if (!string.IsNullOrEmpty(originalPath) && dnSpy.Contracts.Utilities.GacInfo.IsGacPath(originalPath!))
+                        throw new ArgumentException("cannot save GAC assembly (refused by policy)");
+                    if (dnSpy.Contracts.Utilities.GacInfo.IsGacPath(outputPath))
+                        throw new ArgumentException("cannot save to a GAC path (refused by policy)");
+
+                    // Backup-then-overwrite when we're writing to an existing file.
+                    string? backupPath = null;
+                    bool overwritingOriginal = !string.IsNullOrEmpty(originalPath) &&
+                        string.Equals(System.IO.Path.GetFullPath(originalPath!), outputPath, StringComparison.OrdinalIgnoreCase);
+                    if (overwritingOriginal && System.IO.File.Exists(outputPath))
+                    {
+                        var stamp = DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
+                        backupPath = outputPath + "." + stamp + ".bak";
+                        System.IO.File.Copy(outputPath, backupPath, overwrite: false);
+                        settings.Log($"Backed up {outputPath} → {System.IO.Path.GetFileName(backupPath)}");
+                    }
+
+                    // Disable memory-mapped I/O on every loaded document whose filename matches
+                    // the target. Matches AsmEditor's MmapDisabler pattern — a single file may
+                    // be referenced by more than one IDsDocument (main file, resources, etc.).
+                    foreach (var doc in documentTreeView.DocumentService.GetDocuments())
+                    {
+                        if (string.IsNullOrEmpty(doc.Filename))
+                            continue;
+                        if (!string.Equals(doc.Filename, outputPath, StringComparison.OrdinalIgnoreCase))
+                            continue;
+                        (doc.PEImage as dnlib.PE.IInternalPEImage)?.UnsafeDisableMemoryMappedIO();
+                    }
+
+                    // Write. ModuleDefMD (loaded from disk) uses NativeWrite so native stubs,
+                    // Win32 resources, delay-loaded imports and mixed-mode code survive.
+                    // Freshly-constructed modules go through plain Write.
+                    if (module is ModuleDefMD md)
+                    {
+                        var opts = new dnlib.DotNet.Writer.NativeModuleWriterOptions(md, optimizeImageSize: true);
+                        opts.MetadataOptions.Flags |= dnlib.DotNet.Writer.MetadataFlags.RoslynSortInterfaceImpl;
+                        md.NativeWrite(outputPath, opts);
+                    }
+                    else
+                    {
+                        var opts = new dnlib.DotNet.Writer.ModuleWriterOptions(module);
+                        opts.MetadataOptions.Flags |= dnlib.DotNet.Writer.MetadataFlags.RoslynSortInterfaceImpl;
+                        module.Write(outputPath, opts);
+                    }
+
+                    long bytes = 0;
+                    try { bytes = new System.IO.FileInfo(outputPath).Length; } catch { /* ignore */ }
+
+                    settings.Log($"save_assembly: {assemblyName} → {outputPath} ({bytes} bytes)" + (backupPath != null ? $", backup {System.IO.Path.GetFileName(backupPath)}" : ""));
+
+                    var result = new Dictionary<string, object?>
+                    {
+                        ["saved_to"] = outputPath,
+                        ["bytes_written"] = bytes,
+                        ["backup_path"] = backupPath,
+                        ["note"] = "dnSpy's in-memory view is NOT refreshed. Reopen the assembly in dnSpy to see the saved state."
+                    };
+                    var json = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+                    return new CallToolResult
+                    {
+                        Content = new List<ToolContent> {
+                            new ToolContent { Text = json }
+                        }
+                    };
+                }
+            });
+        }
+
+        // ---------- edit parsing + resolving ----------
+
+        sealed class EditOp
+        {
+            public string Op { get; set; } = string.Empty;
+            public int Index { get; set; }
+            public string? OpCodeName { get; set; }
+            public string? OperandRaw { get; set; }
+            public bool? BoolValue { get; set; }
+        }
+
+        sealed class ResolvedEdit
+        {
+            public string Op { get; set; } = string.Empty;
+            public int Index { get; set; }
+            public Instruction? Target { get; set; }
+            public OpCode? NewOpCode { get; set; }
+            public object? NewOperand { get; set; }
+            public bool? BoolValue { get; set; }
+        }
+
+        static List<EditOp> ParseEditsList(object? raw)
+        {
+            if (raw == null)
+                throw new ArgumentException("edits must be an array");
+
+            var list = new List<EditOp>();
+
+            if (raw is JsonElement el)
+            {
+                if (el.ValueKind != JsonValueKind.Array)
+                    throw new ArgumentException("edits must be a JSON array");
+                foreach (var item in el.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.Object)
+                        throw new ArgumentException("each edit must be an object");
+                    list.Add(ParseEditObject(item));
+                }
+                return list;
+            }
+
+            if (raw is IEnumerable<object> seq)
+            {
+                foreach (var item in seq)
+                {
+                    if (item is JsonElement je)
+                        list.Add(ParseEditObject(je));
+                    else if (item is Dictionary<string, object> dict)
+                        list.Add(ParseEditDict(dict));
+                    else
+                        throw new ArgumentException($"unsupported edit shape: {item?.GetType().Name}");
+                }
+                return list;
+            }
+
+            throw new ArgumentException("edits must be an array of objects");
+        }
+
+        static EditOp ParseEditObject(JsonElement obj)
+        {
+            var e = new EditOp();
+            if (!obj.TryGetProperty("op", out var opEl) || opEl.ValueKind != JsonValueKind.String)
+                throw new ArgumentException("edit.op (string) is required");
+            e.Op = opEl.GetString() ?? string.Empty;
+
+            if (obj.TryGetProperty("index", out var idxEl) && idxEl.ValueKind == JsonValueKind.Number && idxEl.TryGetInt32(out var idx))
+                e.Index = idx;
+            if (obj.TryGetProperty("opcode", out var oc) && oc.ValueKind == JsonValueKind.String)
+                e.OpCodeName = oc.GetString();
+            if (obj.TryGetProperty("operand", out var op))
+                e.OperandRaw = op.ValueKind == JsonValueKind.String ? op.GetString() : op.ToString();
+            if (obj.TryGetProperty("value", out var v))
+            {
+                if (v.ValueKind == JsonValueKind.True) e.BoolValue = true;
+                else if (v.ValueKind == JsonValueKind.False) e.BoolValue = false;
+            }
+            return e;
+        }
+
+        static EditOp ParseEditDict(Dictionary<string, object> dict)
+        {
+            var e = new EditOp();
+            if (!dict.TryGetValue("op", out var opObj) || opObj == null)
+                throw new ArgumentException("edit.op is required");
+            e.Op = opObj.ToString() ?? string.Empty;
+            if (dict.TryGetValue("index", out var idxObj) && idxObj != null)
+                e.Index = Convert.ToInt32(idxObj, CultureInfo.InvariantCulture);
+            if (dict.TryGetValue("opcode", out var ocObj) && ocObj != null)
+                e.OpCodeName = ocObj.ToString();
+            if (dict.TryGetValue("operand", out var opdObj) && opdObj != null)
+                e.OperandRaw = opdObj.ToString();
+            if (dict.TryGetValue("value", out var vObj) && vObj != null)
+            {
+                if (vObj is bool b) e.BoolValue = b;
+                else if (bool.TryParse(vObj.ToString(), out var pb)) e.BoolValue = pb;
+            }
+            return e;
+        }
+
+        ResolvedEdit ResolveEdit(EditOp e, IList<Instruction> originalList, CilBody body, MethodDef method, Importer importer)
+        {
+            var r = new ResolvedEdit { Op = e.Op, Index = e.Index, BoolValue = e.BoolValue };
+            switch (e.Op)
+            {
+                case "replace":
+                case "delete":
+                    if (e.Index < 0 || e.Index >= originalList.Count)
+                        throw new ArgumentException($"{e.Op} index {e.Index} out of range [0,{originalList.Count})");
+                    r.Target = originalList[e.Index];
+                    if (e.Op == "replace")
+                    {
+                        if (string.IsNullOrEmpty(e.OpCodeName))
+                            throw new ArgumentException("replace requires opcode");
+                        r.NewOpCode = ParseOpCode(e.OpCodeName!);
+                        r.NewOperand = ParseOperand(e.OperandRaw ?? string.Empty, r.NewOpCode!, originalList, body, method, importer);
+                    }
+                    return r;
+                case "insert":
+                    if (e.Index < 0 || e.Index > originalList.Count)
+                        throw new ArgumentException($"insert index {e.Index} out of range [0,{originalList.Count}]");
+                    r.Target = e.Index < originalList.Count ? originalList[e.Index] : null; // null = append
+                    if (string.IsNullOrEmpty(e.OpCodeName))
+                        throw new ArgumentException("insert requires opcode");
+                    r.NewOpCode = ParseOpCode(e.OpCodeName!);
+                    r.NewOperand = ParseOperand(e.OperandRaw ?? string.Empty, r.NewOpCode!, originalList, body, method, importer);
+                    return r;
+                case "set_init_locals":
+                    if (!e.BoolValue.HasValue)
+                        throw new ArgumentException("set_init_locals requires value (bool)");
+                    return r;
+                default:
+                    throw new ArgumentException($"Unknown edit op: {e.Op}");
+            }
+        }
+
+        // ---------- opcode parser ----------
+
+        static Dictionary<string, OpCode>? opCodeByName;
+        static readonly object opCodeByNameLock = new object();
+
+        static OpCode ParseOpCode(string name)
+        {
+            if (opCodeByName == null)
+            {
+                lock (opCodeByNameLock)
+                {
+                    if (opCodeByName == null)
+                    {
+                        var map = new Dictionary<string, OpCode>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var f in typeof(OpCodes).GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
+                        {
+                            if (f.FieldType != typeof(OpCode))
+                                continue;
+                            var oc = (OpCode)f.GetValue(null)!;
+                            map[oc.Name] = oc;
+                        }
+                        opCodeByName = map;
+                    }
+                }
+            }
+            if (opCodeByName!.TryGetValue(name, out var result))
+                return result;
+            throw new ArgumentException($"Unknown opcode: '{name}'. Use dnlib names like 'ldarg.0', 'ldc.i4.s', 'brtrue.s', 'callvirt'.");
+        }
+
+        // ---------- operand parser ----------
+
+        object? ParseOperand(string operandRaw, OpCode opcode, IList<Instruction> originalList, CilBody body, MethodDef method, Importer importer)
+        {
+            var ot = opcode.OperandType;
+            if (ot == OperandType.InlineNone)
+                return null;
+
+            var s = operandRaw ?? string.Empty;
+            var colon = s.IndexOf(':');
+            if (colon < 0)
+                throw new ArgumentException($"operand '{s}' for {opcode.Name} must be tagged (e.g. 'int:1', 'str:\"x\"', 'label:3'). See the patch_method_il doc.");
+            var tag = s.Substring(0, colon);
+            var rest = s.Substring(colon + 1);
+
+            switch (ot)
+            {
+                case OperandType.InlineI:
+                    ExpectTag(tag, opcode, "int");
+                    return int.Parse(rest, CultureInfo.InvariantCulture);
+                case OperandType.ShortInlineI:
+                    if (tag == "int8") return sbyte.Parse(rest, CultureInfo.InvariantCulture);
+                    if (tag == "uint8") return byte.Parse(rest, CultureInfo.InvariantCulture);
+                    throw new ArgumentException($"operand for {opcode.Name} needs 'int8:' or 'uint8:' tag, got '{tag}:'");
+                case OperandType.InlineI8:
+                    ExpectTag(tag, opcode, "long");
+                    return long.Parse(rest, CultureInfo.InvariantCulture);
+                case OperandType.ShortInlineR:
+                    ExpectTag(tag, opcode, "float");
+                    return float.Parse(rest, CultureInfo.InvariantCulture);
+                case OperandType.InlineR:
+                    ExpectTag(tag, opcode, "double");
+                    return double.Parse(rest, CultureInfo.InvariantCulture);
+                case OperandType.InlineString:
+                    ExpectTag(tag, opcode, "str");
+                    // rest is a JSON-quoted string literal, e.g. "hello\n"
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(rest);
+                        if (doc.RootElement.ValueKind != JsonValueKind.String)
+                            throw new ArgumentException("str: operand must be a JSON-quoted string");
+                        return doc.RootElement.GetString() ?? string.Empty;
+                    }
+                    catch (JsonException ex)
+                    {
+                        throw new ArgumentException($"Invalid JSON string in str: operand: {ex.Message}");
+                    }
+                case OperandType.InlineMethod:
+                    ExpectTag(tag, opcode, "method");
+                    return ResolveMethodRef(rest, importer);
+                case OperandType.InlineField:
+                    ExpectTag(tag, opcode, "field");
+                    return ResolveFieldRef(rest, importer);
+                case OperandType.InlineType:
+                    ExpectTag(tag, opcode, "type");
+                    return ResolveTypeRef(rest, importer);
+                case OperandType.InlineTok:
+                    ExpectTag(tag, opcode, "token");
+                    // rest is e.g. "method:...", "field:...", "type:..."
+                    var tokColon = rest.IndexOf(':');
+                    if (tokColon < 0)
+                        throw new ArgumentException("token operand must be 'token:method:...', 'token:field:...', or 'token:type:...'");
+                    var innerTag = rest.Substring(0, tokColon);
+                    var innerRest = rest.Substring(tokColon + 1);
+                    return innerTag switch
+                    {
+                        "method" => (object)ResolveMethodRef(innerRest, importer),
+                        "field" => ResolveFieldRef(innerRest, importer),
+                        "type" => ResolveTypeRef(innerRest, importer),
+                        _ => throw new ArgumentException($"unknown token inner tag '{innerTag}'")
+                    };
+                case OperandType.InlineBrTarget:
+                case OperandType.ShortInlineBrTarget:
+                    ExpectTag(tag, opcode, "label");
+                    {
+                        var idx = int.Parse(rest, CultureInfo.InvariantCulture);
+                        if (idx < 0 || idx >= originalList.Count)
+                            throw new ArgumentException($"label:{idx} out of range [0,{originalList.Count})");
+                        return originalList[idx];
+                    }
+                case OperandType.InlineSwitch:
+                    ExpectTag(tag, opcode, "switch");
+                    if (!rest.StartsWith("[") || !rest.EndsWith("]"))
+                        throw new ArgumentException("switch operand must be 'switch:[<i>,<i>,...]'");
+                    var inner = rest.Substring(1, rest.Length - 2);
+                    if (string.IsNullOrWhiteSpace(inner))
+                        return Array.Empty<Instruction>();
+                    return inner.Split(',').Select(part =>
+                    {
+                        var idx = int.Parse(part.Trim(), CultureInfo.InvariantCulture);
+                        if (idx < 0 || idx >= originalList.Count)
+                            throw new ArgumentException($"switch label {idx} out of range [0,{originalList.Count})");
+                        return originalList[idx];
+                    }).ToArray();
+                case OperandType.InlineVar:
+                case OperandType.ShortInlineVar:
+                    if (tag == "local")
+                    {
+                        var idx = int.Parse(rest, CultureInfo.InvariantCulture);
+                        if (idx < 0 || idx >= body.Variables.Count)
+                            throw new ArgumentException($"local:{idx} out of range [0,{body.Variables.Count})");
+                        return body.Variables[idx];
+                    }
+                    if (tag == "arg")
+                    {
+                        var idx = int.Parse(rest, CultureInfo.InvariantCulture);
+                        if (idx < 0 || idx >= method.Parameters.Count)
+                            throw new ArgumentException($"arg:{idx} out of range [0,{method.Parameters.Count})");
+                        return method.Parameters[idx];
+                    }
+                    throw new ArgumentException($"operand for {opcode.Name} needs 'local:' or 'arg:', got '{tag}:'");
+                case OperandType.InlineSig:
+                    throw new ArgumentException("calli / InlineSig operands are not supported in this release");
+                default:
+                    throw new ArgumentException($"operand type {ot} not supported in this release");
+            }
+        }
+
+        static void ExpectTag(string actual, OpCode opcode, string expected)
+        {
+            if (!string.Equals(actual, expected, StringComparison.Ordinal))
+                throw new ArgumentException($"operand for {opcode.Name} needs '{expected}:' tag, got '{actual}:'");
+        }
+
+        // ---------- member reference resolvers ----------
+
+        IMethod ResolveMethodRef(string fullName, Importer importer)
+        {
+            var needle = fullName.Trim();
+            foreach (var mnode in documentTreeView.GetAllModuleNodes())
+            {
+                var mod = mnode.Document?.ModuleDef;
+                if (mod == null) continue;
+                foreach (var t in mod.GetTypes())
+                {
+                    foreach (var m in t.Methods)
+                    {
+                        if (string.Equals(m.FullName, needle, StringComparison.Ordinal))
+                            return importer.Import(m);
+                    }
+                }
+            }
+            throw new ArgumentException($"No method with FullName '{needle}' in any loaded assembly. Copy the 'signature' field from list_methods.");
+        }
+
+        IField ResolveFieldRef(string fullName, Importer importer)
+        {
+            var needle = fullName.Trim();
+            foreach (var mnode in documentTreeView.GetAllModuleNodes())
+            {
+                var mod = mnode.Document?.ModuleDef;
+                if (mod == null) continue;
+                foreach (var t in mod.GetTypes())
+                {
+                    foreach (var f in t.Fields)
+                    {
+                        if (string.Equals(f.FullName, needle, StringComparison.Ordinal))
+                            return importer.Import(f);
+                    }
+                }
+            }
+            throw new ArgumentException($"No field with FullName '{needle}' in any loaded assembly. Copy from get_type_info.Fields[].");
+        }
+
+        ITypeDefOrRef ResolveTypeRef(string fullName, Importer importer)
+        {
+            var needle = fullName.Trim();
+            foreach (var mnode in documentTreeView.GetAllModuleNodes())
+            {
+                var mod = mnode.Document?.ModuleDef;
+                if (mod == null) continue;
+                foreach (var t in mod.GetTypes())
+                {
+                    if (string.Equals(t.FullName, needle, StringComparison.Ordinal))
+                        return importer.Import(t);
+                }
+            }
+            throw new ArgumentException($"No type with FullName '{needle}' in any loaded assembly.");
+        }
+
+        // ---------- small helper added here so both phases can reach it ----------
+
+        static bool? ReadOptionalBool(Dictionary<string, object> args, string key)
+        {
+            if (!args.TryGetValue(key, out var raw) || raw == null)
+                return null;
+            if (raw is bool b) return b;
+            if (raw is JsonElement el)
+            {
+                if (el.ValueKind == JsonValueKind.True) return true;
+                if (el.ValueKind == JsonValueKind.False) return false;
+                if (el.ValueKind == JsonValueKind.Null) return null;
+                if (el.ValueKind == JsonValueKind.String && bool.TryParse(el.GetString(), out var pb)) return pb;
+            }
+            if (bool.TryParse(raw.ToString(), out var rp)) return rp;
+            throw new ArgumentException($"{key} must be a boolean");
+        }
+
+        // ---------- shared body → JSON projection ----------
+
+        Dictionary<string, object?> SerializeBody(MethodDef method, CilBody body)
+        {
+            var instrs = body.Instructions;
+            var indexMap = new Dictionary<Instruction, int>(instrs.Count);
+            for (int i = 0; i < instrs.Count; i++)
+                indexMap[instrs[i]] = i;
+
+            var rendered = new List<object>(instrs.Count);
+            for (int i = 0; i < instrs.Count; i++)
+            {
+                var ins = instrs[i];
+                rendered.Add(new Dictionary<string, object?>
+                {
+                    ["index"] = i,
+                    ["offset"] = (int)ins.Offset,
+                    ["opcode"] = ins.OpCode.Name,
+                    ["operand"] = RenderOperand(ins, indexMap)
+                });
+            }
+
+            var locals = body.Variables.Select((v, i) => new Dictionary<string, object?>
+            {
+                ["index"] = i,
+                ["type"] = v.Type?.FullName ?? "?",
+                ["name"] = string.IsNullOrEmpty(v.Name) ? null : v.Name
+            }).ToList();
+
+            var handlers = body.ExceptionHandlers.Select(eh => new Dictionary<string, object?>
+            {
+                ["handler_type"] = eh.HandlerType.ToString(),
+                ["try_start"] = IndexOrEnd(eh.TryStart, indexMap, instrs.Count),
+                ["try_end"] = IndexOrEnd(eh.TryEnd, indexMap, instrs.Count),
+                ["handler_start"] = IndexOrEnd(eh.HandlerStart, indexMap, instrs.Count),
+                ["handler_end"] = IndexOrEnd(eh.HandlerEnd, indexMap, instrs.Count),
+                ["filter_start"] = IndexOrEnd(eh.FilterStart, indexMap, instrs.Count),
+                ["catch_type"] = eh.CatchType?.FullName
+            }).ToList();
+
+            return new Dictionary<string, object?>
+            {
+                ["method"] = new Dictionary<string, object?>
+                {
+                    ["name"] = method.Name.String,
+                    ["token"] = method.MDToken.Raw,
+                    ["signature"] = method.FullName
+                },
+                ["instructions"] = rendered,
+                ["max_stack"] = (int)body.MaxStack,
+                ["init_locals"] = body.InitLocals,
+                ["keep_old_max_stack"] = body.KeepOldMaxStack,
+                ["local_var_sig_tok"] = body.LocalVarSigTok,
+                ["locals"] = locals,
+                ["exception_handlers"] = handlers,
+                ["has_pending_patch"] = ilSnapshots.ContainsKey(method.MDToken.Raw)
+            };
+        }
+
+        static int? IndexOrEnd(Instruction? target, Dictionary<Instruction, int> indexMap, int count)
+        {
+            if (target == null)
+                return null;
+            return indexMap.TryGetValue(target, out var idx) ? idx : count;
+        }
+
+        // ---------- operand renderer ----------
+
+        /// <summary>
+        /// Serializes an instruction operand into the tagged grammar described in the feature plan.
+        /// Mirrored by <c>ParseOperand</c> (added in the patch_method_il step) for round-tripping.
+        /// </summary>
+        static string RenderOperand(Instruction ins, Dictionary<Instruction, int> indexMap)
+        {
+            var op = ins.Operand;
+            switch (ins.OpCode.OperandType)
+            {
+                case OperandType.InlineNone:
+                    return string.Empty;
+                case OperandType.InlineI:
+                    return op == null ? "int:0" : "int:" + Convert.ToInt32(op, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
+                case OperandType.ShortInlineI:
+                    // Operand is sbyte for ldc.i4.s; byte for unaligned. prefix, volatile. etc. use inline:
+                    return op == null ? "int8:0" : (op is byte b
+                        ? "uint8:" + b.ToString(CultureInfo.InvariantCulture)
+                        : "int8:" + Convert.ToSByte(op, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture));
+                case OperandType.InlineI8:
+                    return op == null ? "long:0" : "long:" + Convert.ToInt64(op, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
+                case OperandType.ShortInlineR:
+                    return op == null ? "float:0" : "float:" + Convert.ToSingle(op, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture);
+                case OperandType.InlineR:
+                    return op == null ? "double:0" : "double:" + Convert.ToDouble(op, CultureInfo.InvariantCulture).ToString("R", CultureInfo.InvariantCulture);
+                case OperandType.InlineString:
+                    return "str:" + JsonSerializer.Serialize(op as string ?? string.Empty);
+                case OperandType.InlineMethod:
+                    return op == null ? "method:?" : "method:" + ((IMethod)op).FullName;
+                case OperandType.InlineField:
+                    return op == null ? "field:?" : "field:" + ((IField)op).FullName;
+                case OperandType.InlineType:
+                    return op == null ? "type:?" : "type:" + ((ITypeDefOrRef)op).FullName;
+                case OperandType.InlineTok:
+                    return op switch
+                    {
+                        IMethod m => "token:method:" + m.FullName,
+                        IField f => "token:field:" + f.FullName,
+                        ITypeDefOrRef t => "token:type:" + t.FullName,
+                        null => "token:?",
+                        _ => "token:?:" + op
+                    };
+                case OperandType.InlineBrTarget:
+                case OperandType.ShortInlineBrTarget:
+                    if (op is Instruction target && indexMap.TryGetValue(target, out var tidx))
+                        return "label:" + tidx.ToString(CultureInfo.InvariantCulture);
+                    return "label:-1";
+                case OperandType.InlineSwitch:
+                    if (op is IList<Instruction> targets)
+                    {
+                        var ids = targets.Select(t => t != null && indexMap.TryGetValue(t, out var x) ? x : -1);
+                        return "switch:[" + string.Join(",", ids) + "]";
+                    }
+                    if (op is Instruction[] arr)
+                    {
+                        var ids = arr.Select(t => t != null && indexMap.TryGetValue(t, out var x) ? x : -1);
+                        return "switch:[" + string.Join(",", ids) + "]";
+                    }
+                    return "switch:[]";
+                case OperandType.InlineVar:
+                case OperandType.ShortInlineVar:
+                    if (op is Local local)
+                        return "local:" + local.Index.ToString(CultureInfo.InvariantCulture);
+                    if (op is Parameter parameter)
+                        return "arg:" + parameter.Index.ToString(CultureInfo.InvariantCulture);
+                    return op?.ToString() ?? "?";
+                case OperandType.InlineSig:
+                    return "sig:" + (op?.ToString() ?? "?");
+                case OperandType.InlinePhi:
+                    return "phi:" + (op?.ToString() ?? "?");
+                default:
+                    return op?.ToString() ?? string.Empty;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pre-patch snapshot of a CilBody used by revert_method_il. Captures both the ordering of
+    /// Instruction references AND each instruction's (OpCode, Operand) — the replace path
+    /// mutates Instruction objects in place so we can preserve branch-target identity, and
+    /// that mutation would otherwise poison a reference-only snapshot.
+    /// </summary>
+    sealed class CilBodySnapshot
+    {
+        public List<InstructionSnapshot> Instructions { get; set; } = new List<InstructionSnapshot>();
+        public List<Local> Variables { get; set; } = new List<Local>();
+        public List<ExceptionHandler> ExceptionHandlers { get; set; } = new List<ExceptionHandler>();
+        public ushort MaxStack { get; set; }
+        public bool InitLocals { get; set; }
+        public bool KeepOldMaxStack { get; set; }
+    }
+
+    sealed class InstructionSnapshot
+    {
+        public Instruction Instr { get; set; } = null!;
+        public OpCode OpCode { get; set; } = null!;
+        public object? Operand { get; set; }
+    }
+}

--- a/McpTools.cs
+++ b/McpTools.cs
@@ -17,19 +17,21 @@ namespace dnSpy.Extension.MCP
     /// Provides tools for listing assemblies, inspecting types, decompiling methods, and generating BepInEx plugins.
     /// </summary>
     [Export(typeof(McpTools))]
-    sealed class McpTools
+    sealed partial class McpTools
     {
         readonly IDocumentTreeView documentTreeView;
         readonly IDecompilerService decompilerService;
+        readonly McpSettings settings;
 
         /// <summary>
         /// Initializes the MCP tools with dnSpy services.
         /// </summary>
         [ImportingConstructor]
-        public McpTools(IDocumentTreeView documentTreeView, IDecompilerService decompilerService)
+        public McpTools(IDocumentTreeView documentTreeView, IDecompilerService decompilerService, McpSettings settings)
         {
             this.documentTreeView = documentTreeView;
             this.decompilerService = decompilerService;
+            this.settings = settings;
         }
 
         /// <summary>
@@ -111,7 +113,7 @@ namespace dnSpy.Extension.MCP
                 },
                 new ToolInfo {
                     Name = "decompile_method",
-                    Description = "Decompile a specific method to C# code",
+                    Description = "Decompile a specific method to C# code. For overloaded methods, pass parameter_types (array of fully-qualified type names from list_methods) or method_token (uint MDToken) to disambiguate.",
                     InputSchema = new Dictionary<string, object> {
                         ["type"] = "object",
                         ["properties"] = new Dictionary<string, object> {
@@ -126,6 +128,15 @@ namespace dnSpy.Extension.MCP
                             ["method_name"] = new Dictionary<string, object> {
                                 ["type"] = "string",
                                 ["description"] = "Name of the method"
+                            },
+                            ["parameter_types"] = new Dictionary<string, object> {
+                                ["type"] = "array",
+                                ["items"] = new Dictionary<string, object> { ["type"] = "string" },
+                                ["description"] = "Optional. Fully-qualified parameter type names (e.g. [\"System.Int32\",\"System.String\"]) to disambiguate overloads. Matches MethodSig.Params, not including 'this'."
+                            },
+                            ["method_token"] = new Dictionary<string, object> {
+                                ["type"] = "integer",
+                                ["description"] = "Optional. MDToken.Raw as uint (from get_type_info or list_methods). Unambiguous — takes precedence over parameter_types."
                             }
                         },
                         ["required"] = new List<string> { "assembly_name", "type_full_name", "method_name" }
@@ -255,6 +266,121 @@ namespace dnSpy.Extension.MCP
                         },
                         ["required"] = new List<string> { "assembly_name", "from_type", "to_type" }
                     }
+                },
+                new ToolInfo {
+                    Name = "list_methods",
+                    Description = "List methods of a type with unambiguous identifiers. Each entry includes the MDToken (as uint) and parameter_types array so the caller can feed either back into get_method_il / patch_method_il / decompile_method to disambiguate overloads. Paginated (default page size 10).",
+                    InputSchema = new Dictionary<string, object> {
+                        ["type"] = "object",
+                        ["properties"] = new Dictionary<string, object> {
+                            ["assembly_name"] = new Dictionary<string, object> {
+                                ["type"] = "string",
+                                ["description"] = "Name of the assembly"
+                            },
+                            ["type_full_name"] = new Dictionary<string, object> {
+                                ["type"] = "string",
+                                ["description"] = "Fully qualified type name"
+                            },
+                            ["cursor"] = new Dictionary<string, object> {
+                                ["type"] = "string",
+                                ["description"] = "Opaque pagination cursor from a previous response."
+                            }
+                        },
+                        ["required"] = new List<string> { "assembly_name", "type_full_name" }
+                    }
+                },
+                new ToolInfo {
+                    Name = "get_method_il",
+                    Description = "Return the IL body of a method: instructions (index, offset, opcode, operand), locals, exception handlers, and body flags. Operand format is tagged and round-trips with patch_method_il (e.g. 'int:42', 'str:\"hello\"', 'method:Ns.T::M(System.Int32):System.Void', 'label:7'). For overloaded methods, pass parameter_types or method_token to disambiguate.",
+                    InputSchema = new Dictionary<string, object> {
+                        ["type"] = "object",
+                        ["properties"] = new Dictionary<string, object> {
+                            ["assembly_name"] = new Dictionary<string, object> {
+                                ["type"] = "string",
+                                ["description"] = "Name of the assembly"
+                            },
+                            ["type_full_name"] = new Dictionary<string, object> {
+                                ["type"] = "string",
+                                ["description"] = "Fully qualified type name"
+                            },
+                            ["method_name"] = new Dictionary<string, object> {
+                                ["type"] = "string",
+                                ["description"] = "Method name"
+                            },
+                            ["parameter_types"] = new Dictionary<string, object> {
+                                ["type"] = "array",
+                                ["items"] = new Dictionary<string, object> { ["type"] = "string" },
+                                ["description"] = "Optional. Fully-qualified parameter type names for overload disambiguation."
+                            },
+                            ["method_token"] = new Dictionary<string, object> {
+                                ["type"] = "integer",
+                                ["description"] = "Optional. MDToken.Raw from list_methods / get_type_info. Takes precedence over parameter_types."
+                            }
+                        },
+                        ["required"] = new List<string> { "assembly_name", "type_full_name", "method_name" }
+                    }
+                },
+                new ToolInfo {
+                    Name = "patch_method_il",
+                    Description = "Apply an ordered list of IL edits to a method body in memory. Ops: {op:\"replace\",index,opcode,operand}, {op:\"insert\",index,opcode,operand} (insert BEFORE index), {op:\"delete\",index}, {op:\"set_init_locals\",value:bool}. Indices in later ops refer to the state BEFORE the whole batch. Operand grammar matches get_method_il output. Set optimize_macros=true to auto-shorten after edits. Changes are NOT written to disk — call save_assembly to persist. First patch to a method is snapshotted so revert_method_il can restore it.",
+                    InputSchema = new Dictionary<string, object> {
+                        ["type"] = "object",
+                        ["properties"] = new Dictionary<string, object> {
+                            ["assembly_name"] = new Dictionary<string, object> { ["type"] = "string" },
+                            ["type_full_name"] = new Dictionary<string, object> { ["type"] = "string" },
+                            ["method_name"] = new Dictionary<string, object> { ["type"] = "string" },
+                            ["parameter_types"] = new Dictionary<string, object> {
+                                ["type"] = "array",
+                                ["items"] = new Dictionary<string, object> { ["type"] = "string" }
+                            },
+                            ["method_token"] = new Dictionary<string, object> { ["type"] = "integer" },
+                            ["edits"] = new Dictionary<string, object> {
+                                ["type"] = "array",
+                                ["description"] = "Ordered edit ops. See tool description for shape."
+                            },
+                            ["optimize_macros"] = new Dictionary<string, object> {
+                                ["type"] = "boolean",
+                                ["description"] = "Call body.OptimizeMacros() after edits to auto-shorten ldarg/ldloc/branches. Default false."
+                            }
+                        },
+                        ["required"] = new List<string> { "assembly_name", "type_full_name", "method_name", "edits" }
+                    }
+                },
+                new ToolInfo {
+                    Name = "revert_method_il",
+                    Description = "Restore the method body that was captured on first patch_method_il. Fails with -32602 if no pending snapshot exists for the method.",
+                    InputSchema = new Dictionary<string, object> {
+                        ["type"] = "object",
+                        ["properties"] = new Dictionary<string, object> {
+                            ["assembly_name"] = new Dictionary<string, object> { ["type"] = "string" },
+                            ["type_full_name"] = new Dictionary<string, object> { ["type"] = "string" },
+                            ["method_name"] = new Dictionary<string, object> { ["type"] = "string" },
+                            ["parameter_types"] = new Dictionary<string, object> {
+                                ["type"] = "array",
+                                ["items"] = new Dictionary<string, object> { ["type"] = "string" }
+                            },
+                            ["method_token"] = new Dictionary<string, object> { ["type"] = "integer" }
+                        },
+                        ["required"] = new List<string> { "assembly_name", "type_full_name", "method_name" }
+                    }
+                },
+                new ToolInfo {
+                    Name = "save_assembly",
+                    Description = "Write the (possibly patched) module of an assembly back to disk. When output_path is omitted, the original file is overwritten after a timestamped backup (<path>.<yyyyMMdd-HHmmss>.bak) is created. GAC paths are refused. Memory-mapped I/O is disabled before writing so the live dnSpy process releases the file. Note: dnSpy's in-memory tree is NOT refreshed — reopen the assembly to see the saved state inside this instance.",
+                    InputSchema = new Dictionary<string, object> {
+                        ["type"] = "object",
+                        ["properties"] = new Dictionary<string, object> {
+                            ["assembly_name"] = new Dictionary<string, object> {
+                                ["type"] = "string",
+                                ["description"] = "Name of the assembly to save"
+                            },
+                            ["output_path"] = new Dictionary<string, object> {
+                                ["type"] = "string",
+                                ["description"] = "Optional. Target file path. If absent, overwrite original with a timestamped backup."
+                            }
+                        },
+                        ["required"] = new List<string> { "assembly_name" }
+                    }
                 }
             };
         }
@@ -267,39 +393,53 @@ namespace dnSpy.Extension.MCP
         /// <returns>The tool execution result.</returns>
         public CallToolResult ExecuteTool(string toolName, Dictionary<string, object>? arguments)
         {
-            try
+            // Marshal every tool handler onto the WPF UI thread. dnSpy's document tree
+            // is a DispatcherObject — the moment a user-loaded assembly is indexed, all
+            // downstream tree/node reads from an HTTP worker thread throw
+            // "calling thread cannot access this object". Patch/save already take this
+            // path explicitly; InvokeOnUiThread short-circuits when already on the UI
+            // thread, so the double-wrap is a no-op.
+            return InvokeOnUiThread(() =>
             {
-                return toolName switch
+                try
                 {
-                    "list_assemblies" => ListAssemblies(),
-                    "get_assembly_info" => GetAssemblyInfo(arguments),
-                    "list_types" => ListTypes(arguments),
-                    "get_type_info" => GetTypeInfo(arguments),
-                    "decompile_method" => DecompileMethod(arguments),
-                    "search_types" => SearchTypes(arguments),
-                    "generate_bepinex_plugin" => GenerateBepInExPlugin(arguments),
-                    "get_type_fields" => GetTypeFields(arguments),
-                    "get_type_property" => GetTypeProperty(arguments),
-                    "find_path_to_type" => FindPathToType(arguments),
-                    _ => new CallToolResult
+                    return toolName switch
+                    {
+                        "list_assemblies" => ListAssemblies(),
+                        "get_assembly_info" => GetAssemblyInfo(arguments),
+                        "list_types" => ListTypes(arguments),
+                        "get_type_info" => GetTypeInfo(arguments),
+                        "decompile_method" => DecompileMethod(arguments),
+                        "search_types" => SearchTypes(arguments),
+                        "generate_bepinex_plugin" => GenerateBepInExPlugin(arguments),
+                        "get_type_fields" => GetTypeFields(arguments),
+                        "get_type_property" => GetTypeProperty(arguments),
+                        "find_path_to_type" => FindPathToType(arguments),
+                        "list_methods" => ListMethods(arguments),
+                        "get_method_il" => GetMethodIL(arguments),
+                        "patch_method_il" => PatchMethodIL(arguments),
+                        "revert_method_il" => RevertMethodIL(arguments),
+                        "save_assembly" => SaveAssembly(arguments),
+                        _ => new CallToolResult
+                        {
+                            Content = new List<ToolContent> {
+                                new ToolContent { Text = $"Unknown tool: {toolName}" }
+                            },
+                            IsError = true
+                        }
+                    };
+                }
+                catch (Exception ex)
+                {
+                    return new CallToolResult
                     {
                         Content = new List<ToolContent> {
-                            new ToolContent { Text = $"Unknown tool: {toolName}" }
+                            new ToolContent { Text = $"Error executing tool {toolName}: {ex.Message}" }
                         },
                         IsError = true
-                    }
-                };
-            }
-            catch (Exception ex)
-            {
-                return new CallToolResult
-                {
-                    Content = new List<ToolContent> {
-                        new ToolContent { Text = $"Error executing tool {toolName}: {ex.Message}" }
-                    },
-                    IsError = true
-                };
-            }
+                    };
+                }
+            });
         }
 
         CallToolResult ListAssemblies()
@@ -460,12 +600,14 @@ namespace dnSpy.Extension.MCP
             var allMethods = type.Methods.Select(m => new
             {
                 Name = m.Name.String,
+                Token = m.MDToken.Raw,
                 Signature = m.FullName,
                 IsPublic = m.IsPublic,
                 IsStatic = m.IsStatic,
                 IsVirtual = m.IsVirtual,
                 IsAbstract = m.IsAbstract,
                 ReturnType = m.ReturnType?.FullName ?? "void",
+                ParameterTypes = m.MethodSig == null ? new List<string>() : m.MethodSig.Params.Select(t => t?.FullName ?? "?").ToList(),
                 Parameters = m.Parameters.Select(p => new
                 {
                     Name = p.Name,
@@ -558,6 +700,9 @@ namespace dnSpy.Extension.MCP
             var typeFullName = typeNameObj.ToString() ?? string.Empty;
             var methodName = methodNameObj.ToString() ?? string.Empty;
 
+            var parameterTypes = ReadStringArray(arguments, "parameter_types");
+            uint? methodToken = ReadOptionalUInt(arguments, "method_token");
+
             var assembly = FindAssemblyByName(assemblyName);
             if (assembly == null)
                 throw new ArgumentException($"Assembly not found: {assemblyName}");
@@ -566,9 +711,7 @@ namespace dnSpy.Extension.MCP
             if (type == null)
                 throw new ArgumentException($"Type not found: {typeFullName}");
 
-            var method = type.Methods.FirstOrDefault(m => m.Name == methodName);
-            if (method == null)
-                throw new ArgumentException($"Method not found: {methodName}");
+            var method = FindMethod(type, methodName, parameterTypes, methodToken);
 
             // Decompile the method
             var decompiler = decompilerService.Decompiler;
@@ -997,6 +1140,114 @@ namespace dnSpy.Extension.MCP
             return assembly.Modules
                 .SelectMany(m => m.Types)
                 .FirstOrDefault(t => t.FullName.Equals(fullName, StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// Resolves a method by name, optionally disambiguated by parameter types or MDToken.
+        /// Resolution order: token &gt; parameter_types &gt; name-only.
+        /// Throws ArgumentException (-> JSON-RPC -32602) on 0 or &gt;1 matches, with a candidate list
+        /// when multiple overloads share the name so the caller can retry with parameter_types.
+        /// </summary>
+        MethodDef FindMethod(TypeDef type, string methodName, IList<string>? parameterTypes, uint? methodToken)
+        {
+            var candidates = type.Methods.Where(m => m.Name == methodName).ToList();
+            if (candidates.Count == 0)
+                throw new ArgumentException($"Method not found: {type.FullName}::{methodName}");
+
+            if (methodToken.HasValue)
+            {
+                var byToken = candidates.FirstOrDefault(m => m.MDToken.Raw == methodToken.Value)
+                    ?? type.Methods.FirstOrDefault(m => m.MDToken.Raw == methodToken.Value);
+                if (byToken == null)
+                    throw new ArgumentException($"No method in {type.FullName} has MDToken 0x{methodToken.Value:X8}");
+                return byToken;
+            }
+
+            if (parameterTypes != null)
+            {
+                var matches = candidates.Where(m => MethodParamTypesMatch(m, parameterTypes)).ToList();
+                if (matches.Count == 1)
+                    return matches[0];
+                if (matches.Count == 0)
+                    throw new ArgumentException(
+                        $"No overload of {type.FullName}::{methodName} has parameters [{string.Join(", ", parameterTypes)}]. " +
+                        $"Candidates: {string.Join(" | ", candidates.Select(DescribeSignature))}");
+                throw new ArgumentException(
+                    $"Ambiguous match for {type.FullName}::{methodName}: {matches.Count} overloads matched. " +
+                    $"Use method_token instead. Matches: {string.Join(" | ", matches.Select(DescribeSignature))}");
+            }
+
+            if (candidates.Count > 1)
+                throw new ArgumentException(
+                    $"{type.FullName}::{methodName} is overloaded ({candidates.Count}). Pass parameter_types or method_token. " +
+                    $"Candidates: {string.Join(" | ", candidates.Select(DescribeSignature))}");
+
+            return candidates[0];
+        }
+
+        static bool MethodParamTypesMatch(MethodDef m, IList<string> expected)
+        {
+            var sig = m.MethodSig;
+            if (sig == null)
+                return expected.Count == 0;
+            if (sig.Params.Count != expected.Count)
+                return false;
+            for (int i = 0; i < expected.Count; i++)
+            {
+                var actual = sig.Params[i]?.FullName ?? string.Empty;
+                if (!string.Equals(actual, expected[i], StringComparison.Ordinal))
+                    return false;
+            }
+            return true;
+        }
+
+        static string DescribeSignature(MethodDef m)
+        {
+            var sig = m.MethodSig;
+            var @params = sig == null ? string.Empty : string.Join(",", sig.Params.Select(t => t?.FullName ?? "?"));
+            var ret = m.ReturnType?.FullName ?? "void";
+            return $"{m.Name}({@params}):{ret}#0x{m.MDToken.Raw:X8}";
+        }
+
+        static IList<string>? ReadStringArray(Dictionary<string, object> args, string key)
+        {
+            if (!args.TryGetValue(key, out var raw) || raw == null)
+                return null;
+            if (raw is JsonElement el)
+            {
+                if (el.ValueKind == JsonValueKind.Null)
+                    return null;
+                if (el.ValueKind != JsonValueKind.Array)
+                    throw new ArgumentException($"{key} must be an array of strings");
+                var list = new List<string>(el.GetArrayLength());
+                foreach (var item in el.EnumerateArray())
+                    list.Add(item.ValueKind == JsonValueKind.String ? (item.GetString() ?? string.Empty) : item.ToString());
+                return list;
+            }
+            if (raw is IEnumerable<object> seq)
+                return seq.Select(o => o?.ToString() ?? string.Empty).ToList();
+            throw new ArgumentException($"{key} must be an array of strings");
+        }
+
+        static uint? ReadOptionalUInt(Dictionary<string, object> args, string key)
+        {
+            if (!args.TryGetValue(key, out var raw) || raw == null)
+                return null;
+            if (raw is JsonElement el)
+            {
+                if (el.ValueKind == JsonValueKind.Null)
+                    return null;
+                if (el.ValueKind == JsonValueKind.Number && el.TryGetUInt32(out var u))
+                    return u;
+                if (el.ValueKind == JsonValueKind.String && uint.TryParse(el.GetString(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var su))
+                    return su;
+                throw new ArgumentException($"{key} must be an unsigned 32-bit integer");
+            }
+            if (raw is string s && uint.TryParse(s, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var ps))
+                return ps;
+            if (raw is IConvertible conv)
+                return Convert.ToUInt32(conv, System.Globalization.CultureInfo.InvariantCulture);
+            throw new ArgumentException($"{key} must be an unsigned 32-bit integer");
         }
 
         /// <summary>

--- a/dnSpy.Extension.MCP.csproj
+++ b/dnSpy.Extension.MCP.csproj
@@ -6,6 +6,10 @@
     <AssemblyName>dnSpy.Extension.MCP.x</AssemblyName>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <!-- The SDK implicitly globs every .cs file under the project root. Keep the
+         test fixture (tests/fixtures/) and its generated obj/ out of our compile
+         so building the extension doesn't pull in TestIL.cs / AssemblyInfo.cs. -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);tests/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/fixtures/TestIL.cs
+++ b/tests/fixtures/TestIL.cs
@@ -1,0 +1,28 @@
+namespace TestIL
+{
+    public static class Simple
+    {
+        public static int AddOne(int x) => x + 1;
+
+        public static int Add(int a, int b) => a + b;
+        public static int Add(int a, int b, int c) => a + b + c;
+
+        public static string Greet(string name) => "Hello, " + name;
+
+        public static int Branch(int x)
+        {
+            if (x > 0)
+                return 1;
+            return -1;
+        }
+
+        static int counter;
+        public static int Inc()
+        {
+            counter = counter + 1;
+            return counter;
+        }
+
+        public static object[] MakeArray() => new string[3];
+    }
+}

--- a/tests/fixtures/TestIL.csproj
+++ b/tests/fixtures/TestIL.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>TestIL</AssemblyName>
+    <RootNamespace>TestIL</RootNamespace>
+    <Nullable>disable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <DebugType>portable</DebugType>
+    <Deterministic>false</Deterministic>
+  </PropertyGroup>
+
+</Project>

--- a/tests/fixtures/build-fixture.ps1
+++ b/tests/fixtures/build-fixture.ps1
@@ -1,0 +1,49 @@
+#Requires -Version 5.0
+<#
+.SYNOPSIS
+  Builds the TestIL.dll fixture used by run-tests.ps1.
+
+.DESCRIPTION
+  Compiles TestIL.cs → bin/TestIL.dll via the side-car TestIL.csproj. The DLL
+  itself is gitignored; the source + csproj + this script are the tracked
+  reproduction recipe.
+
+.PARAMETER Clean
+  Delete any previous output (obj/, bin/) before building.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+$fixtureDir = $PSScriptRoot
+$csproj = Join-Path $fixtureDir 'TestIL.csproj'
+$binDir = Join-Path $fixtureDir 'bin'
+$objDir = Join-Path $fixtureDir 'obj'
+
+if ($Clean)
+{
+    if (Test-Path $binDir) { Remove-Item -Recurse -Force $binDir }
+    if (Test-Path $objDir) { Remove-Item -Recurse -Force $objDir }
+}
+
+Write-Host "Building TestIL fixture → $binDir/TestIL.dll"
+& dotnet build $csproj -c Release -o $binDir --nologo -v q
+if ($LASTEXITCODE -ne 0)
+{
+    throw "dotnet build failed with exit code $LASTEXITCODE"
+}
+
+$dll = Join-Path $binDir 'TestIL.dll'
+if (-not (Test-Path $dll))
+{
+    throw "Build reported success but TestIL.dll is missing at $dll"
+}
+
+$hash = (Get-FileHash -Algorithm SHA256 $dll).Hash
+$bytes = (Get-Item $dll).Length
+Write-Host "  path:  $dll"
+Write-Host "  size:  $bytes bytes"
+Write-Host "  sha256: $hash"

--- a/tests/fixtures/run-tests.ps1
+++ b/tests/fixtures/run-tests.ps1
@@ -1,0 +1,278 @@
+#Requires -Version 5.0
+<#
+.SYNOPSIS
+  End-to-end smoke test for the MCP extension's IL view/edit/save tools.
+
+.DESCRIPTION
+  1. Builds TestIL.dll fixture (via build-fixture.ps1).
+  2. Deploys the just-built MCP extension DLL into dnSpy's Extensions folder.
+  3. Launches dnSpy (net10.0-windows release build) with TestIL.dll preloaded.
+  4. Waits for /health on the configured port (default 3000, with +N fallback).
+  5. Walks through a sequence of list_methods / decompile_method / get_method_il /
+     patch_method_il / revert_method_il / save_assembly calls, asserting expected
+     responses and on-disk state.
+
+  Each step prints PASS/FAIL. Non-zero exit code on first FAIL.
+
+.PARAMETER Port
+  First port to probe (default 3000). Falls back to 3000..3019 if dnSpy landed
+  on a later port due to the in-use fallback.
+
+.PARAMETER DnSpyExe
+  Path to dnSpy.exe. Defaults to the Release/net10.0-windows build in-tree.
+
+.PARAMETER SkipBuild
+  Skip `dotnet build` steps (assume fixture + extension are already up to date).
+
+.PARAMETER KeepDnSpy
+  Leave dnSpy running after the tests exit (handy for ad-hoc follow-up curls).
+#>
+
+[CmdletBinding()]
+param(
+    # Default 3100 because WSL's wslrelay.exe typically holds 3000 on dev boxes,
+    # which collides with HttpListener.Start even when TcpListener probes clean.
+    [int]$Port = 3100,
+    [string]$DnSpyExe,
+    [switch]$SkipBuild,
+    [switch]$KeepDnSpy
+)
+
+$ErrorActionPreference = 'Stop'
+$fixtureDir = $PSScriptRoot
+if (-not $DnSpyExe) { $DnSpyExe = Join-Path $fixtureDir '..\..\..\..\dnSpy\dnSpy\bin\Release\net10.0-windows\dnSpy.exe' }
+
+# Force dnSpy's MCP server onto the port we want by rewriting the persisted setting.
+# The GUID must match McpSettingsImpl's SETTINGS_GUID.
+function Set-McpPortInSettings([int]$p)
+{
+    $cfg = Join-Path $env:APPDATA 'dnSpy\dnSpy.xml'
+    if (-not (Test-Path $cfg)) { return }
+    [xml]$doc = Get-Content -Raw -Path $cfg
+    $sect = $doc.SelectSingleNode("//section[@_='352907a0-9df5-4b2b-b47b-95e504cac301']")
+    if ($sect -eq $null) { return }
+    $sect.SetAttribute('Port', "$p")
+    $sect.SetAttribute('EnableServer', 'True')
+    $doc.Save($cfg)
+    Write-Host "  dnSpy.xml: set MCP Port=$p, EnableServer=True"
+}
+$extDir = Split-Path $fixtureDir -Parent | Split-Path -Parent
+$binFixture = Join-Path $fixtureDir 'bin'
+$testDll = Join-Path $binFixture 'TestIL.dll'
+$extDllSrc = Join-Path $extDir 'bin\Release\net10.0-windows\dnSpy.Extension.MCP.x.dll'
+$resolved = Resolve-Path $DnSpyExe -ErrorAction SilentlyContinue
+if (-not $resolved) { throw "dnSpy.exe not found at $DnSpyExe. Build the Release/net10.0-windows config first." }
+$dnSpyExeFull = $resolved.Path
+$extDeployDir = Join-Path (Split-Path $dnSpyExeFull -Parent) 'bin\Extensions\dnSpy.Extension.MCP'
+
+$pass = 0; $fail = 0
+function Assert($condition, [string]$label, [string]$detail = '')
+{
+    if ($condition) { Write-Host "  PASS  $label" -ForegroundColor Green; $script:pass++ }
+    else { Write-Host "  FAIL  $label  $detail" -ForegroundColor Red; $script:fail++ }
+}
+
+function Rpc([string]$tool, [hashtable]$arguments, [int]$p = $script:Port)
+{
+    $payload = @{ jsonrpc='2.0'; id=1; method='tools/call'; params=@{ name=$tool; arguments=$arguments } } | ConvertTo-Json -Depth 10 -Compress
+    $resp = Invoke-WebRequest -Uri "http://localhost:$p/" -Method Post -ContentType 'application/json' -Body $payload -UseBasicParsing
+    $jr = $resp.Content | ConvertFrom-Json
+    if ($jr.error) { throw "Tool $tool RPC error: $($jr.error.message)" }
+    if ($jr.result.isError -eq $true) { throw "Tool $tool returned error: $($jr.result.content[0].text)" }
+    $text = $jr.result.content[0].text
+    return ($text | ConvertFrom-Json)
+}
+
+function RpcText([string]$tool, [hashtable]$arguments, [int]$p = $script:Port)
+{
+    $payload = @{ jsonrpc='2.0'; id=1; method='tools/call'; params=@{ name=$tool; arguments=$arguments } } | ConvertTo-Json -Depth 10 -Compress
+    $resp = Invoke-WebRequest -Uri "http://localhost:$p/" -Method Post -ContentType 'application/json' -Body $payload -UseBasicParsing
+    $jr = $resp.Content | ConvertFrom-Json
+    if ($jr.error) { throw "Tool $tool RPC error: $($jr.error.message)" }
+    if ($jr.result.isError -eq $true) { throw "Tool $tool returned error: $($jr.result.content[0].text)" }
+    return $jr.result.content[0].text
+}
+
+# ----- step 1: build fixture -----
+if (-not $SkipBuild)
+{
+    Write-Host "[1] Building TestIL.dll fixture"
+    & (Join-Path $fixtureDir 'build-fixture.ps1') -Clean
+    Write-Host ""
+
+    Write-Host "[2] Building MCP extension (Release)"
+    Push-Location $extDir
+    try { & dotnet build -c Release --nologo -v q; if ($LASTEXITCODE -ne 0) { throw "extension build failed" } }
+    finally { Pop-Location }
+    Write-Host ""
+}
+
+if (-not (Test-Path $testDll)) { throw "Fixture DLL missing: $testDll" }
+if (-not (Test-Path $extDllSrc)) { throw "Extension DLL missing: $extDllSrc" }
+
+$originalHash = (Get-FileHash -Algorithm SHA256 $testDll).Hash
+Write-Host "[*] Fixture SHA256 (pre-patch): $originalHash"
+
+# ----- step 3: deploy extension -----
+Write-Host "[3] Deploying extension → $extDeployDir"
+if (-not (Test-Path $extDeployDir)) { New-Item -ItemType Directory -Path $extDeployDir | Out-Null }
+Copy-Item $extDllSrc $extDeployDir -Force
+$pdb = [System.IO.Path]::ChangeExtension($extDllSrc, '.pdb')
+if (Test-Path $pdb) { Copy-Item $pdb $extDeployDir -Force }
+
+# ----- step 4: launch dnSpy with the fixture preloaded -----
+Write-Host "[4] Launching dnSpy + loading $testDll"
+Set-McpPortInSettings $Port
+$dnSpyProc = Start-Process -FilePath $dnSpyExeFull -ArgumentList $testDll -PassThru
+
+# Poll for /health on the configured port with +N fallback (McpServer's FindAvailablePort tries up to 20).
+$found = $false
+$deadline = (Get-Date).AddSeconds(45)
+while ((Get-Date) -lt $deadline -and -not $found)
+{
+    for ($p = $Port; $p -lt $Port + 20; $p++)
+    {
+        try
+        {
+            $h = Invoke-WebRequest -Uri "http://localhost:$p/health" -UseBasicParsing -TimeoutSec 1
+            if ($h.StatusCode -eq 200) { $script:Port = $p; $found = $true; break }
+        }
+        catch { }
+    }
+    if (-not $found) { Start-Sleep -Milliseconds 500 }
+}
+if (-not $found) { throw "MCP server never came up on ports $Port..$($Port+19)" }
+Write-Host "  MCP server is up on port $script:Port"
+
+# Wait for TestIL to actually appear in the tree. dnSpy loads CLI-provided files
+# asynchronously, so the health port can come up before the assembly is indexed.
+$loaded = $false
+$deadline = (Get-Date).AddSeconds(30)
+while ((Get-Date) -lt $deadline -and -not $loaded)
+{
+    try
+    {
+        $asmList = Rpc 'list_assemblies' @{}
+        if ($asmList | Where-Object { $_.Name -eq 'TestIL' }) { $loaded = $true; break }
+    }
+    catch { }
+    Start-Sleep -Milliseconds 500
+}
+if (-not $loaded) { throw "TestIL never appeared in list_assemblies — did dnSpy fail to load the fixture?" }
+Write-Host "  TestIL assembly is loaded"
+Write-Host ""
+
+try
+{
+    # ----- step 5-7: reads on TestIL.Simple -----
+    Write-Host "[5] list_methods on TestIL.Simple"
+    $listed = Rpc 'list_methods' @{ assembly_name='TestIL'; type_full_name='TestIL.Simple' }
+    $addOverloads = $listed.items | Where-Object { $_.name -eq 'Add' }
+    Assert ($addOverloads.Count -eq 2) "two Add overloads in list_methods" "got $($addOverloads.Count)"
+    $addOne = $listed.items | Where-Object { $_.name -eq 'AddOne' } | Select-Object -First 1
+    Assert ($addOne -ne $null) "AddOne present"
+    Assert ($addOne.parameter_types.Count -eq 1 -and $addOne.parameter_types[0] -eq 'System.Int32') "AddOne param types"
+    Assert ($addOne.token -gt 0) "AddOne MDToken > 0"
+
+    Write-Host ""
+    Write-Host "[6] decompile_method Add(int,int,int) — overload disambiguation"
+    $srcText = RpcText 'decompile_method' @{
+        assembly_name='TestIL'; type_full_name='TestIL.Simple'; method_name='Add';
+        parameter_types=@('System.Int32','System.Int32','System.Int32')
+    }
+    Assert ($srcText -match 'a \+ b \+ c' -or $srcText -match 'int c') "3-arg overload selected (source references c)" "src:`n$srcText"
+    # Also confirm the 2-arg lookup works.
+    $srcText2 = RpcText 'decompile_method' @{
+        assembly_name='TestIL'; type_full_name='TestIL.Simple'; method_name='Add';
+        parameter_types=@('System.Int32','System.Int32')
+    }
+    Assert (($srcText2 -match 'a \+ b') -and ($srcText2 -notmatch '\+ c')) "2-arg overload selected (no c)"
+    # Ambiguous call without disambiguator should get a helpful error.
+    $ambiguous = $null
+    try { Rpc 'decompile_method' @{ assembly_name='TestIL'; type_full_name='TestIL.Simple'; method_name='Add' } | Out-Null }
+    catch { $ambiguous = $_.Exception.Message }
+    Assert ($ambiguous -and ($ambiguous -match 'overloaded' -or $ambiguous -match 'parameter_types')) "ambiguous Add call errors with helpful guidance" "got: $ambiguous"
+
+    Write-Host ""
+    Write-Host "[7] get_method_il on AddOne"
+    $il = Rpc 'get_method_il' @{ assembly_name='TestIL'; type_full_name='TestIL.Simple'; method_name='AddOne' }
+    $opcodes = @($il.instructions.opcode)
+    Assert ($opcodes -contains 'ldarg.0') "AddOne IL contains ldarg.0"
+    Assert ($opcodes -contains 'add') "AddOne IL contains add"
+    Assert ($opcodes -contains 'ret') "AddOne IL contains ret"
+    $one = $il.instructions | Where-Object { $_.opcode -match '^ldc\.i4' -and $_.operand -eq 'int:1' }
+    if (-not $one) { $one = $il.instructions | Where-Object { $_.opcode -eq 'ldc.i4.1' } }
+    Assert ($one -ne $null) "AddOne loads constant 1 (ldc.i4.1 or ldc.i4 int:1)"
+
+    # ----- step 8-10: patch + revert in memory -----
+    Write-Host ""
+    Write-Host "[8] patch_method_il AddOne: replace the +1 constant with +41"
+    $loadOneIdx = ($il.instructions | Where-Object { $_.opcode -match '^ldc\.i4' -and ($_.operand -eq 'int:1' -or $_.opcode -eq 'ldc.i4.1') } | Select-Object -First 1).index
+    Assert ($loadOneIdx -ne $null) "found ldc.i4 loading 1"
+    $patched = Rpc 'patch_method_il' @{
+        assembly_name='TestIL'; type_full_name='TestIL.Simple'; method_name='AddOne';
+        edits = @(@{ op='replace'; index=$loadOneIdx; opcode='ldc.i4'; operand='int:41' })
+    }
+    Assert ($patched.edits_applied -eq 1) "edits_applied == 1"
+    Assert ($patched.has_pending_patch -eq $true) "has_pending_patch is true"
+    $after = $patched.instructions | Where-Object { $_.index -eq $loadOneIdx }
+    Assert ($after.opcode -eq 'ldc.i4' -and $after.operand -eq 'int:41') "instruction is now ldc.i4 int:41"
+
+    Write-Host ""
+    Write-Host "[9] revert_method_il AddOne"
+    $reverted = Rpc 'revert_method_il' @{ assembly_name='TestIL'; type_full_name='TestIL.Simple'; method_name='AddOne' }
+    Assert ($reverted.reverted -eq $true) "revert returned reverted=true"
+    $restored = $reverted.instructions | Where-Object { $_.index -eq $loadOneIdx }
+    $originalOpcode = ($il.instructions | Where-Object { $_.index -eq $loadOneIdx }).opcode
+    $originalOperand = ($il.instructions | Where-Object { $_.index -eq $loadOneIdx }).operand
+    Assert (($restored.opcode -eq $originalOpcode) -and ($restored.operand -eq $originalOperand)) "AddOne instruction restored to original shape" "restored=$($restored.opcode)/$($restored.operand) original=$originalOpcode/$originalOperand"
+
+    # ----- step 10: save to a side path (non-destructive) -----
+    Write-Host ""
+    Write-Host "[10] re-apply patch + save_assembly to side path"
+    Rpc 'patch_method_il' @{
+        assembly_name='TestIL'; type_full_name='TestIL.Simple'; method_name='AddOne';
+        edits=@(@{ op='replace'; index=$loadOneIdx; opcode='ldc.i4'; operand='int:41' })
+    } | Out-Null
+    $sidePath = Join-Path $binFixture 'TestIL.patched.dll'
+    if (Test-Path $sidePath) { Remove-Item $sidePath -Force }
+    $saved = Rpc 'save_assembly' @{ assembly_name='TestIL'; output_path=$sidePath }
+    Assert ((Test-Path $sidePath)) "side-path file written"
+    Assert ($saved.backup_path -eq $null) "no backup for side-path save"
+    Assert ($saved.bytes_written -gt 0) "bytes_written > 0"
+
+    # Prove the IL change is persisted on disk.
+    $verify = & powershell -NoProfile -Command "[Reflection.Assembly]::LoadFile('$sidePath') | Out-Null; [TestIL.Simple]::AddOne(10)"
+    Assert ($verify -eq '51') "AddOne(10) on disk returns 51 (was 11 before patch)" "got $verify"
+
+    # ----- step 11: overwrite original with backup -----
+    Write-Host ""
+    Write-Host "[11] save_assembly overwriting original (backup-then-overwrite)"
+    $savedOver = Rpc 'save_assembly' @{ assembly_name='TestIL' }
+    Assert ($savedOver.backup_path -ne $null -and (Test-Path $savedOver.backup_path)) "backup exists" "backup=$($savedOver.backup_path)"
+    $backupHash = (Get-FileHash -Algorithm SHA256 $savedOver.backup_path).Hash
+    Assert ($backupHash -eq $originalHash) "backup SHA matches pre-patch bytes" "backup=$backupHash original=$originalHash"
+    $newHash = (Get-FileHash -Algorithm SHA256 $testDll).Hash
+    Assert ($newHash -ne $originalHash) "original file bytes changed"
+
+    Write-Host ""
+    Write-Host "[12] cleanup revert (drop snapshot)"
+    $reverted2 = Rpc 'revert_method_il' @{ assembly_name='TestIL'; type_full_name='TestIL.Simple'; method_name='AddOne' }
+    Assert ($reverted2.reverted -eq $true) "second revert works"
+}
+finally
+{
+    Write-Host ""
+    Write-Host "===== SUMMARY: $pass pass / $fail fail ====="
+    if (-not $KeepDnSpy -and $dnSpyProc -and -not $dnSpyProc.HasExited)
+    {
+        Write-Host "Stopping dnSpy PID $($dnSpyProc.Id)"
+        try { Stop-Process -Id $dnSpyProc.Id -Force -ErrorAction SilentlyContinue } catch { }
+    }
+    elseif ($KeepDnSpy -and $dnSpyProc)
+    {
+        Write-Host "Leaving dnSpy (PID $($dnSpyProc.Id)) running per -KeepDnSpy"
+    }
+}
+
+if ($fail -ne 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
Five new MCP tools build out the flow the Edit Method Body dialog covers: list_methods (tokens + parameter_types for unambiguous overload lookup), get_method_il (instructions + locals + handlers + flags in a tagged-operand grammar), patch_method_il (replace/insert/delete/ set_init_locals with snapshot-on-first-patch), revert_method_il (restore pre-patch shape by un-mutating Instructions in place), and save_assembly (mmap-disable, timestamped backup, NativeWrite for ModuleDefMD, GAC refusal). decompile_method now accepts parameter_types / method_token to fix the long-standing overload bug, and get_type_info surfaces MDTokens so a single round-trip gives the AI everything it needs to target a specific method.

ExecuteTool marshals every handler onto the WPF UI thread - IDocumentTreeView nodes are DispatcherObjects and throw the moment a user-loaded assembly is indexed, so reads have to run on the UI thread too. McpTools is split into McpTools.cs (dispatch, schemas, shared helpers) and McpTools.IL.cs (IL handlers, operand renderer/parser, snapshot store) as a sealed partial class.

Verification is driven by tests/fixtures/run-tests.ps1, which builds TestIL.dll from TestIL.cs, deploys the extension, launches dnSpy, and walks list_methods -> decompile_method -> get_method_il -> patch_method_il -> revert_method_il -> save_assembly with SHA256 and behavioural asserts. A spawned PowerShell loads the saved DLL and invokes AddOne(10); after replacing ldc.i4.1 with ldc.i4 int:41 it returns 51 instead of 11, proving the patched IL actually runs.

25/25 pass. See CLAUDE.md for the IL-editing conventions.