### PR TITLE
Stop logging ERROR for resources/templates/list probes

### DIFF
--- a/McpServer.cs
+++ b/McpServer.cs
@@ -496,6 +496,7 @@ namespace dnSpy.Extension.MCP {
 					"tools/list" => HandleListTools(),
 					"tools/call" => HandleCallTool(request.Params),
 					"resources/list" => HandleListResources(),
+					"resources/templates/list" => HandleListResourceTemplates(),
 					"resources/read" => HandleReadResource(request.Params),
 					_ => throw new Exception($"Unknown method: {request.Method}")
 				};
@@ -575,6 +576,8 @@ namespace dnSpy.Extension.MCP {
 				Resources = bepinexResources.GetResources()
 			};
 		}
+
+		object HandleListResourceTemplates() => new { resourceTemplates = Array.Empty<object>() };
 
 		object HandleReadResource(Dictionary<string, object>? parameters) {
 			if (parameters == null)


### PR DESCRIPTION
MCP clients (Claude, MCP Inspector) probe resources/templates/list during init to discover parameterized-resource URI templates. We don't expose any, but throwing "Unknown method" spammed the log on every connect. Handle the method and return an empty array.