### PR TITLE
Fix patch_method_il schema: define edits.items

### DIFF
--- a/McpTools.cs
+++ b/McpTools.cs
@@ -336,6 +336,47 @@ namespace dnSpy.Extension.MCP
                             ["method_token"] = new Dictionary<string, object> { ["type"] = "integer" },
                             ["edits"] = new Dictionary<string, object> {
                                 ["type"] = "array",
+                                ["items"] = new Dictionary<string, object> {
+                                    ["type"] = "object",
+                                    ["oneOf"] = new List<object> {
+                                        new Dictionary<string, object> {
+                                            ["properties"] = new Dictionary<string, object> {
+                                                ["op"] = new Dictionary<string, object> { ["const"] = "replace" },
+                                                ["index"] = new Dictionary<string, object> { ["type"] = "integer" },
+                                                ["opcode"] = new Dictionary<string, object> { ["type"] = "string" },
+                                                ["operand"] = new Dictionary<string, object> { ["type"] = "string" }
+                                            },
+                                            ["required"] = new List<string> { "op", "index", "opcode", "operand" },
+                                            ["additionalProperties"] = false
+                                        },
+                                        new Dictionary<string, object> {
+                                            ["properties"] = new Dictionary<string, object> {
+                                                ["op"] = new Dictionary<string, object> { ["const"] = "insert" },
+                                                ["index"] = new Dictionary<string, object> { ["type"] = "integer" },
+                                                ["opcode"] = new Dictionary<string, object> { ["type"] = "string" },
+                                                ["operand"] = new Dictionary<string, object> { ["type"] = "string" }
+                                            },
+                                            ["required"] = new List<string> { "op", "index", "opcode", "operand" },
+                                            ["additionalProperties"] = false
+                                        },
+                                        new Dictionary<string, object> {
+                                            ["properties"] = new Dictionary<string, object> {
+                                                ["op"] = new Dictionary<string, object> { ["const"] = "delete" },
+                                                ["index"] = new Dictionary<string, object> { ["type"] = "integer" }
+                                            },
+                                            ["required"] = new List<string> { "op", "index" },
+                                            ["additionalProperties"] = false
+                                        },
+                                        new Dictionary<string, object> {
+                                            ["properties"] = new Dictionary<string, object> {
+                                                ["op"] = new Dictionary<string, object> { ["const"] = "set_init_locals" },
+                                                ["value"] = new Dictionary<string, object> { ["type"] = "boolean" }
+                                            },
+                                            ["required"] = new List<string> { "op", "value" },
+                                            ["additionalProperties"] = false
+                                        }
+                                    }
+                                },
                                 ["description"] = "Ordered edit ops. See tool description for shape."
                             },
                             ["optimize_macros"] = new Dictionary<string, object> {


### PR DESCRIPTION
The `patch_method_il schema` method lacks some type hints. When using it in `vscode` with `github copilot`, it violates the builtin tool validation and breaks the whole session.

<img width="300" alt="CleanShot_2026-04-28_at_01 56 49@2x" src="https://github.com/user-attachments/assets/4fc2eff1-d423-4da0-be9d-ad5fc9c62d64" />




This PR fixes this problem, confirmed after a  clear build.



> 修了一个特定方法缺type hint导致无法在vscode copilot中使用的bug