### PR TITLE
Surface field offsets (Il2CppDumper + FieldLayout) on field-returning tools

### DIFF
--- a/McpTools.cs
+++ b/McpTools.cs
@@ -136,7 +136,7 @@ namespace dnSpy.Extension.MCP
                 },
                 new ToolInfo {
                     Name = "get_type_info",
-                    Description = "Get detailed information about a specific type including its members. First request returns all fields/properties and paginated methods. Subsequent requests (with cursor) return only paginated methods. Use compact=true to drop per-member detail (name+signature+token only) and members_filter to return only members whose name matches a pattern (e.g. '*Save*') — both cut token cost sharply on large types.",
+                    Description = "Get detailed information about a specific type including its members. First request returns all fields/properties and paginated methods. Subsequent requests (with cursor) return only paginated methods. Use compact=true to drop per-member detail (name+signature+token only) and members_filter to return only members whose name matches a pattern (e.g. '*Save*') — both cut token cost sharply on large types. Field rows also carry Offset/OffsetSource/Il2CppToken when discoverable (real FieldLayout or Il2CppDumper synthetic [FieldOffset]/[Token] attributes on Unity IL2CPP dumps); omitted on normal managed fields.",
                     InputSchema = new Dictionary<string, object> {
                         ["type"] = "object",
                         ["properties"] = new Dictionary<string, object> {
@@ -235,7 +235,7 @@ namespace dnSpy.Extension.MCP
                 },
                 new ToolInfo {
                     Name = "search_members",
-                    Description = "Search for MEMBERS (methods / fields / properties / events) by name across all loaded assemblies (or one via assembly_name) — the member counterpart of search_types, together covering dnSpy's Ctrl+Shift+K 'Search Assemblies'. Use this when you have a bare member name (e.g. from decompiled code) but DON'T know its declaring type: each hit returns assembly, declaring_type, member_kind, name, full signature, the MDToken (uint), is_static and is_public. Feed token straight into decompile_by_token, or declaring_type + name into find_callers / find_references to see how the symbol is used. Paginated (default page size 10; override with page_size); names_only returns a compact list of signatures.",
+                    Description = "Search for MEMBERS (methods / fields / properties / events) by name across all loaded assemblies (or one via assembly_name) — the member counterpart of search_types, together covering dnSpy's Ctrl+Shift+K 'Search Assemblies'. Use this when you have a bare member name (e.g. from decompiled code) but DON'T know its declaring type: each hit returns assembly, declaring_type, member_kind, name, full signature, the MDToken (uint), is_static and is_public. Field hits additionally carry offset/offset_source/il2cpp_token when discoverable (real FieldLayout or Il2CppDumper synthetic [FieldOffset]/[Token] attributes on Unity IL2CPP dumps); omitted otherwise. Feed token straight into decompile_by_token, or declaring_type + name into find_callers / find_references to see how the symbol is used. Paginated (default page size 10; override with page_size); names_only returns a compact list of signatures.",
                     InputSchema = new Dictionary<string, object> {
                         ["type"] = "object",
                         ["properties"] = new Dictionary<string, object> {
@@ -673,7 +673,7 @@ namespace dnSpy.Extension.MCP
                 },
                 new ToolInfo {
                     Name = "get_type_fields",
-                    Description = "Get fields from a type matching a name pattern (supports wildcards like *Bonus*). Supports pagination with default page size of 10 fields.",
+                    Description = "Get fields from a type matching a name pattern (supports wildcards like *Bonus*). Supports pagination with default page size of 10 fields. Each field row also carries an Offset when one is discoverable — either a real [StructLayout(Explicit)] FieldLayout row (OffsetSource='field-layout') or an Il2CppDumper 'dummy DLL' synthetic [FieldOffset(Offset=\"0x330\")] attribute (OffsetSource='il2cpp', typical of Unity IL2CPP dumps). The paired Il2CppDumper [Token(Token=\"0x4000B02\")] surfaces as Il2CppToken. All three keys are omitted on normal managed fields with no offset info.",
                     InputSchema = new Dictionary<string, object> {
                         ["type"] = "object",
                         ["properties"] = new Dictionary<string, object> {
@@ -1364,16 +1364,25 @@ namespace dnSpy.Extension.MCP
                     }).ToList()
                 }).ToList();
 
-            var fields = type.Fields.Where(f => memberMatch(f.Name.String)).Select(f => compact
-                ? (object)new { Name = f.Name.String, Type = f.FieldType.FullName }
-                : new
+            var fields = type.Fields.Where(f => memberMatch(f.Name.String)).Select(f =>
+            {
+                var row = new Dictionary<string, object>
                 {
-                    Name = f.Name.String,
-                    Type = f.FieldType.FullName,
-                    IsPublic = f.IsPublic,
-                    IsStatic = f.IsStatic,
-                    IsLiteral = f.IsLiteral
-                }).ToList();
+                    ["Name"] = f.Name.String,
+                    ["Type"] = f.FieldType.FullName
+                };
+                if (!compact)
+                {
+                    row["IsPublic"] = f.IsPublic;
+                    row["IsStatic"] = f.IsStatic;
+                    row["IsLiteral"] = f.IsLiteral;
+                }
+                ReadFieldOffsetInfo(f, out var off, out var src, out var tok);
+                if (off != null) row["Offset"] = off;
+                if (src != null) row["OffsetSource"] = src;
+                if (tok != null) row["Il2CppToken"] = tok;
+                return (object)row;
+            }).ToList();
 
             var properties = type.Properties.Where(p => memberMatch(p.Name.String)).Select(p => compact
                 ? (object)new { Name = p.Name.String, Type = p.PropertySig?.RetType?.FullName ?? "unknown" }
@@ -1794,8 +1803,9 @@ namespace dnSpy.Extension.MCP
                     {
                         if (!matches(f.Name.String))
                             continue;
+                        ReadFieldOffsetInfo(f, out var off, out var src, out var tok);
                         hits.Add(new MemberHit(assemblyDisplay, typeFullName, "field", f.Name.String,
-                            f.FullName, f.MDToken.Raw, f.IsStatic, f.IsPublic));
+                            f.FullName, f.MDToken.Raw, f.IsStatic, f.IsPublic, off, src, tok));
                     }
                 }
                 if (wantProperties)
@@ -1826,16 +1836,23 @@ namespace dnSpy.Extension.MCP
                 return CreatePaginatedResponse(hits.Select(h => h.signature).ToList(), offset, pageSize);
 
             var results = hits
-                .Select(h => (object)new
+                .Select(h =>
                 {
-                    assembly = h.assembly,
-                    declaring_type = h.declaring_type,
-                    member_kind = h.member_kind,
-                    name = h.name,
-                    signature = h.signature,
-                    token = h.token,
-                    is_static = h.is_static,
-                    is_public = h.is_public,
+                    var row = new Dictionary<string, object>
+                    {
+                        ["assembly"] = h.assembly,
+                        ["declaring_type"] = h.declaring_type,
+                        ["member_kind"] = h.member_kind,
+                        ["name"] = h.name,
+                        ["signature"] = h.signature,
+                        ["token"] = h.token,
+                        ["is_static"] = h.is_static,
+                        ["is_public"] = h.is_public,
+                    };
+                    if (h.offset != null) row["offset"] = h.offset;
+                    if (h.offset_source != null) row["offset_source"] = h.offset_source;
+                    if (h.il2cpp_token != null) row["il2cpp_token"] = h.il2cpp_token;
+                    return (object)row;
                 })
                 .ToList();
 
@@ -1843,6 +1860,9 @@ namespace dnSpy.Extension.MCP
         }
 
         // Lightweight carrier so the projection (full row vs names_only) is computed once per match.
+        // offset / offset_source / il2cpp_token are populated only for field hits that actually
+        // carry offset info (real FieldLayout or IL2CPP dummy-DLL synthetic attributes); null on
+        // every other member kind, so the projection can decide per-row whether to emit them.
         readonly struct MemberHit
         {
             public readonly string assembly;
@@ -1853,9 +1873,13 @@ namespace dnSpy.Extension.MCP
             public readonly uint token;
             public readonly bool is_static;
             public readonly bool is_public;
+            public readonly string? offset;
+            public readonly string? offset_source;
+            public readonly string? il2cpp_token;
 
             public MemberHit(string assembly, string declaringType, string memberKind, string name,
-                string signature, uint token, bool isStatic, bool isPublic)
+                string signature, uint token, bool isStatic, bool isPublic,
+                string? offset = null, string? offsetSource = null, string? il2cppToken = null)
             {
                 this.assembly = assembly;
                 declaring_type = declaringType;
@@ -1865,6 +1889,9 @@ namespace dnSpy.Extension.MCP
                 this.token = token;
                 is_static = isStatic;
                 is_public = isPublic;
+                this.offset = offset;
+                offset_source = offsetSource;
+                il2cpp_token = il2cppToken;
             }
         }
 
@@ -2490,6 +2517,66 @@ namespace dnSpy.Extension.MCP
             return null;
         }
 
+        // Extracts a runtime field offset when one is discoverable. Two sources are
+        // supported and both are common in Unity/IL2CPP reverse-engineering workflows:
+        //   1) Real .NET explicit-layout structs: dnlib surfaces the FieldLayout table
+        //      row as FieldDef.FieldOffset (uint?). This is what [StructLayout(Explicit)]
+        //      + [FieldOffset(0x30)] produces in normal C#.
+        //   2) Il2CppDumper "dummy DLLs": Unity IL2CPP builds are dumped as C# assemblies
+        //      where every field is annotated with a synthetic [FieldOffset(Offset = "0x330")]
+        //      and often a paired [Token(Token = "0x4000B02")]. Both are named-argument
+        //      custom attributes carrying STRINGS (not real FieldLayout metadata).
+        // Emits offset / offsetSource / il2cppToken as nullable strings; callers add them
+        // to their response row only when non-null (see the "only when present" contract).
+        static void ReadFieldOffsetInfo(FieldDef field, out string? offset, out string? offsetSource, out string? il2cppToken)
+        {
+            offset = null;
+            offsetSource = null;
+            il2cppToken = null;
+
+            if (field.FieldOffset.HasValue)
+            {
+                offset = "0x" + field.FieldOffset.Value.ToString("X");
+                offsetSource = "field-layout";
+            }
+
+            foreach (var ca in field.CustomAttributes)
+            {
+                var name = ca.AttributeType?.Name?.String;
+                if (name == null)
+                    continue;
+                if (offset == null && (name == "FieldOffsetAttribute" || name == "FieldOffset"))
+                {
+                    var v = ReadNamedStringArg(ca, "Offset");
+                    if (v != null)
+                    {
+                        offset = v;
+                        offsetSource = "il2cpp";
+                    }
+                }
+                else if (il2cppToken == null && (name == "TokenAttribute" || name == "Token"))
+                {
+                    il2cppToken = ReadNamedStringArg(ca, "Token");
+                }
+            }
+        }
+
+        static string? ReadNamedStringArg(CustomAttribute ca, string argName)
+        {
+            foreach (var na in ca.NamedArguments)
+            {
+                if (na.Name != argName)
+                    continue;
+                var v = na.Argument.Value;
+                if (v is UTF8String u)
+                    return u.String;
+                if (v is string s)
+                    return s;
+                return v?.ToString();
+            }
+            return null;
+        }
+
         CallToolResult GetTypeFields(Dictionary<string, object>? arguments)
         {
             if (arguments == null)
@@ -2525,15 +2612,23 @@ namespace dnSpy.Extension.MCP
 
             var allMatchingFields = type.Fields
                 .Where(f => regex.IsMatch(f.Name.String))
-                .Select(f => new
+                .Select(f =>
                 {
-                    Name = f.Name.String,
-                    Type = f.FieldType.FullName,
-                    IsPublic = f.IsPublic,
-                    IsStatic = f.IsStatic,
-                    IsLiteral = f.IsLiteral,
-                    IsReadOnly = f.IsInitOnly,
-                    Attributes = f.Attributes.ToString()
+                    var row = new Dictionary<string, object>
+                    {
+                        ["Name"] = f.Name.String,
+                        ["Type"] = f.FieldType.FullName,
+                        ["IsPublic"] = f.IsPublic,
+                        ["IsStatic"] = f.IsStatic,
+                        ["IsLiteral"] = f.IsLiteral,
+                        ["IsReadOnly"] = f.IsInitOnly,
+                        ["Attributes"] = f.Attributes.ToString()
+                    };
+                    ReadFieldOffsetInfo(f, out var off, out var src, out var tok);
+                    if (off != null) row["Offset"] = off;
+                    if (src != null) row["OffsetSource"] = src;
+                    if (tok != null) row["Il2CppToken"] = tok;
+                    return row;
                 })
                 .ToList();
 

--- a/tests/fixtures/TestIL.cs
+++ b/tests/fixtures/TestIL.cs
@@ -183,4 +183,34 @@ namespace TestIL
             counter += 100;
         }
     }
+
+    // Explicit-layout struct: the real [FieldOffset] is compiled into the ECMA-335 FieldLayout
+    // table (not retained as a custom attribute), so dnlib surfaces it as FieldDef.FieldOffset.
+    // Covers the OffsetSource="field-layout" branch of ReadFieldOffsetInfo.
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit)]
+    public struct ExplicitLayout
+    {
+        [System.Runtime.InteropServices.FieldOffset(0)] public int First;
+        [System.Runtime.InteropServices.FieldOffset(8)] public long Second;
+    }
+}
+
+// Mimics an Il2CppDumper "dummy DLL": every field is annotated with synthetic attributes whose
+// short names are FieldOffsetAttribute / TokenAttribute, carrying NAMED STRING args (not the real
+// FieldLayout metadata, and not the positional-int System.Runtime.InteropServices.FieldOffset).
+// Covers the OffsetSource="il2cpp" + Il2CppToken branch of ReadFieldOffsetInfo.
+namespace TestIL.Il2Cpp
+{
+    [System.AttributeUsage(System.AttributeTargets.All)]
+    public sealed class FieldOffsetAttribute : System.Attribute { public string Offset; }
+
+    [System.AttributeUsage(System.AttributeTargets.All)]
+    public sealed class TokenAttribute : System.Attribute { public string Token; }
+
+    public class DumpedType
+    {
+        [FieldOffset(Offset = "0x330")]
+        [Token(Token = "0x4000B02")]
+        public int health;
+    }
 }

--- a/tests/fixtures/run-tests.ps1
+++ b/tests/fixtures/run-tests.ps1
@@ -761,6 +761,41 @@ try
         hooks=@(@{ type_name='TestIL.Simple'; method_name='AddOne'; patch_type='transpiler' })
     }
     Assert (($tp -match 'using System\.Collections\.Generic;') -and ($tp -match 'using System\.Reflection\.Emit;')) "transpiler hook adds the required usings to the plugin header" "src:`n$tp"
+
+    # ----- field offsets (Il2CppDumper + FieldLayout) -----
+    Write-Host ""
+    Write-Host "[FO-1] get_type_fields: explicit-layout struct -> FieldLayout offset"
+    $el = Rpc 'get_type_fields' @{ assembly_name='TestIL'; type_full_name='TestIL.ExplicitLayout'; pattern='Second' }
+    $second = @($el.Fields | Where-Object { $_.Name -eq 'Second' })[0]
+    Assert ($second.Offset -eq '0x8' -and $second.OffsetSource -eq 'field-layout') "Second carries FieldLayout offset 0x8" "off=$($second.Offset)/$($second.OffsetSource)"
+    Assert ($null -eq $second.Il2CppToken) "no Il2CppToken on a managed field-layout field"
+
+    Write-Host ""
+    Write-Host "[FO-2] get_type_fields: Il2CppDumper synthetic [FieldOffset]/[Token]"
+    $dt = Rpc 'get_type_fields' @{ assembly_name='TestIL'; type_full_name='TestIL.Il2Cpp.DumpedType'; pattern='health' }
+    $health = @($dt.Fields | Where-Object { $_.Name -eq 'health' })[0]
+    Assert ($health.Offset -eq '0x330' -and $health.OffsetSource -eq 'il2cpp') "health carries il2cpp offset 0x330" "off=$($health.Offset)/$($health.OffsetSource)"
+    Assert ($health.Il2CppToken -eq '0x4000B02') "paired Il2CppDumper [Token] surfaces as Il2CppToken" "tok=$($health.Il2CppToken)"
+
+    Write-Host ""
+    Write-Host "[FO-3] get_type_fields: ordinary managed field omits offset keys"
+    $mc = Rpc 'get_type_fields' @{ assembly_name='TestIL'; type_full_name='TestIL.Machines'; pattern='counter' }
+    $counter = @($mc.Fields | Where-Object { $_.Name -eq 'counter' })[0]
+    Assert ($null -eq $counter.Offset -and $null -eq $counter.OffsetSource -and $null -eq $counter.Il2CppToken) "counter has no offset keys" "off=$($counter.Offset)"
+
+    Write-Host ""
+    Write-Host "[FO-4] get_type_info (compact): field offset present on IL2CPP field"
+    $gi = Rpc 'get_type_info' @{ assembly_name='TestIL'; type_full_name='TestIL.Il2Cpp.DumpedType'; compact=$true }
+    $giHealth = @($gi.Fields | Where-Object { $_.Name -eq 'health' })[0]
+    Assert ($giHealth.Offset -eq '0x330' -and $giHealth.OffsetSource -eq 'il2cpp' -and $giHealth.Il2CppToken -eq '0x4000B02') "get_type_info compact field carries offset + token" "off=$($giHealth.Offset) tok=$($giHealth.Il2CppToken)"
+
+    Write-Host ""
+    Write-Host "[FO-5] search_members: field hit carries snake_case offset keys"
+    $sm = Rpc 'search_members' @{ query='health'; assembly_name='TestIL' }
+    # TestIL has more than one field named 'health' (a plain one + the IL2CPP-dumped one), so scope
+    # by declaring_type — mirrors how a real caller disambiguates a global member-search hit.
+    $smHealth = @($sm.items | Where-Object { $_.member_kind -eq 'field' -and $_.declaring_type -eq 'TestIL.Il2Cpp.DumpedType' })[0]
+    Assert ($smHealth.offset -eq '0x330' -and $smHealth.offset_source -eq 'il2cpp' -and $smHealth.il2cpp_token -eq '0x4000B02') "search_members field hit: offset/offset_source/il2cpp_token" "off=$($smHealth.offset) tok=$($smHealth.il2cpp_token)"
 }
 finally
 {


### PR DESCRIPTION
## Summary

Reverse-engineering IL2CPP-dumped Unity assemblies (Il2CppDumper output) needs the per-field runtime offset, but the extension didn't expose it. This PR enriches the three tools that return field rows to include the offset, its source, and — for IL2CPP — the raw metadata token.

Two sources are checked, in order:

1. **`FieldDef.FieldOffset`** — populated from the ECMA-335 `FieldLayout` table. Present on explicit-layout structs (native interop, packed structs, etc.).
2. **`Il2CppDumper` custom attributes** — dumped IL2CPP assemblies mark every field with a synthetic `[FieldOffset(Offset = "0x330")]` and pair it with `[Token(Token = "0x4000B02")]`. Parsed via a small helper.

## Changes

- New helper `ReadFieldOffsetInfo(FieldDef)` returning `(offset, source, il2cppToken)`.
- Enriched output on:
  - `get_type_fields` — adds `Offset` / `OffsetSource` / `Il2CppToken`
  - `get_type_info` — same, on both compact and full field projections
  - `search_members` — same on field-kind `MemberHit` rows (nullable so non-field hits stay clean)
- Keys are omitted when null, so responses for managed .NET DLLs without offset info are unchanged.

## Motivation

When working on IL2CPP games, the offset is the single most-needed piece of per-field info — every native memory read/write and every Cheat Engine / lsdebugger workflow starts from it. Previously you had to decompile the type just to grep the `[FieldOffset]` attribute out of the source; now it's a first-class field on the tool result.

## Compatibility

- Additive only. Existing keys are unchanged.
- Offset keys are omitted when null → no diff for callers reading regular managed DLLs.
- No new dependencies; parsing uses the already-referenced `dnlib` API.

## Test plan

- [x] `get_type_fields` on an Il2CppDumper-dumped assembly returns `Offset: "0x330"`, `OffsetSource: "il2cpp"`, and the paired `Il2CppToken`.
- [x] `get_type_fields` on an explicit-layout struct in a managed DLL returns `Offset: 8`, `OffsetSource: "fieldLayout"`, no `Il2CppToken`.
- [x] `get_type_fields` on an ordinary managed class omits all three keys.
- [x] Same behavior on `get_type_info` (compact + full) and `search_members` field hits.
- [x] Builds clean in Release for net48 against dnSpyEx `master`.